### PR TITLE
Feat/client and market data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ profile.cov
 go.work
 go.work.sum
 
+# CLI binaries
+/authorize
+/envgen
+
 # env file
 .env
 

--- a/client.go
+++ b/client.go
@@ -104,6 +104,34 @@ type authTransport struct {
 }
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+
+	var body []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("buffer request body: %w", err)
+		}
+		body = b
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	req.Header.Set("Authorization", "Bearer "+t.client.currentAccessToken())
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	resp.Body.Close()
+	if err := t.client.refreshAccessToken(req.Context()); err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	req.Header.Set("Authorization", "Bearer "+t.client.currentAccessToken())
 	return t.base.RoundTrip(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -1,7 +1,13 @@
 package tradestation
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sync"
 )
 
@@ -96,4 +102,73 @@ type authTransport struct {
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
+}
+
+func (c *Client) doJSON(
+	ctx context.Context,
+	method, path string,
+	query url.Values,
+	body, out any,
+) error {
+	var reqBody []byte
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		reqBody = b
+	}
+
+	u := c.apiBase + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	var bodyReader io.Reader
+	if reqBody != nil {
+		bodyReader = bytes.NewReader(reqBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, bodyReader)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return parseAPIError(resp)
+	}
+
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func parseAPIError(resp *http.Response) error {
+	raw, _ := io.ReadAll(resp.Body)
+	apiErr := &APIError{StatusCode: resp.StatusCode, RawBody: raw}
+	var parsed struct {
+		Error   string `json:"Error"`
+		Message string `json:"Message"`
+	}
+	if json.Unmarshal(raw, &parsed) == nil {
+		switch {
+		case parsed.Message != "":
+			apiErr.Message = parsed.Message
+		case parsed.Error != "":
+			apiErr.Message = parsed.Error
+		}
+	}
+	return apiErr
 }

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -36,8 +37,9 @@ type Client struct {
 
 	onRotate func(newToken string)
 
-	http    *http.Client // wrapped in authTransport
-	rawHTTP *http.Client // plain — used only for /oauth/token
+	http     *http.Client // wrapped in authTransport
+	rawHTTP  *http.Client // plain — used only for /oauth/token
+	tokenURL string       // override in tests; defaults to signinBaseURL+"/oauth/token"
 }
 
 type Option func(*Client)
@@ -69,6 +71,7 @@ func NewClient(env Environment, clientID, clientSecret, refreshToken string, opt
 		refreshToken: refreshToken,
 		http:         &http.Client{Transport: http.DefaultTransport},
 		rawHTTP:      &http.Client{},
+		tokenURL:     signinBaseURL + "/oauth/token",
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -171,4 +174,56 @@ func parseAPIError(resp *http.Response) error {
 		}
 	}
 	return apiErr
+}
+
+func (c *Client) refreshAccessToken(ctx context.Context) error {
+	c.mu.Lock()
+	rt := c.refreshToken
+	c.mu.Unlock()
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", c.clientID)
+	form.Set("client_secret", c.clientSecret)
+	form.Set("refresh_token", rt)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.rawHTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("refresh: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return parseAPIError(resp)
+	}
+
+	var out struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return fmt.Errorf("decode refresh response: %w", err)
+	}
+
+	c.mu.Lock()
+	c.accessToken = out.AccessToken
+	var rotated string
+	if out.RefreshToken != "" && out.RefreshToken != c.refreshToken {
+		c.refreshToken = out.RefreshToken
+		rotated = out.RefreshToken
+	}
+	onRotate := c.onRotate
+	c.mu.Unlock()
+
+	if rotated != "" && onRotate != nil {
+		onRotate(rotated)
+	}
+	return nil
 }

--- a/client.go
+++ b/client.go
@@ -1,24 +1,99 @@
 package tradestation
 
-import "net/http"
+import (
+	"net/http"
+	"sync"
+)
+
+// Environment selects the TradeStation API base URL.
+type Environment int
+
+const (
+	Test       Environment = iota // sim-api.tradestation.com
+	Production                    // api.tradestation.com
+)
+
+const (
+	testAPIBase   = "https://sim-api.tradestation.com"
+	prodAPIBase   = "https://api.tradestation.com"
+	signinBaseURL = "https://signin.tradestation.com"
+)
 
 type Client struct {
-	BaseURL      string
-	ClientID     string
-	ClientSecret string
-	AccessToken  string
-	RefreshToken string
-	HTTPClient   *http.Client
+	apiBase      string
+	clientID     string
+	clientSecret string
+
+	mu           sync.Mutex // guards accessToken + refreshToken
+	accessToken  string
+	refreshToken string
+
+	onRotate func(newToken string)
+
+	http    *http.Client // wrapped in authTransport
+	rawHTTP *http.Client // plain — used only for /oauth/token
 }
 
-func NewClient(clientID, clientSecret, refreshToken string) *Client {
-	panic("not implemented")
+type Option func(*Client)
+
+// WithHTTPClient lets callers supply a custom *http.Client. Its Transport
+// will be wrapped with the library's authTransport so refresh-on-401 still
+// applies.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h.Transport == nil {
+			h.Transport = http.DefaultTransport
+		}
+		c.http = h
+	}
 }
 
-func (c *Client) Authenticate() error {
-	panic("not implemented")
+// WithRefreshTokenRotate registers a callback invoked when TradeStation
+// returns a new refresh token in response to a refresh request. Useful
+// when the API key is configured with rotating refresh tokens.
+func WithRefreshTokenRotate(fn func(newToken string)) Option {
+	return func(c *Client) { c.onRotate = fn }
 }
 
-func (c *Client) refreshAccessToken() error {
-	panic("not implemented")
+func NewClient(env Environment, clientID, clientSecret, refreshToken string, opts ...Option) *Client {
+	c := &Client{
+		apiBase:      apiBaseForEnvironment(env),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		refreshToken: refreshToken,
+		http:         &http.Client{Transport: http.DefaultTransport},
+		rawHTTP:      &http.Client{},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	// Wrap the final transport (default or caller-supplied) with authTransport.
+	c.http.Transport = &authTransport{base: c.http.Transport, client: c}
+	return c
+}
+
+func apiBaseForEnvironment(env Environment) string {
+	if env == Production {
+		return prodAPIBase
+	}
+	return testAPIBase
+}
+
+// currentAccessToken returns the current access token under the client's
+// mutex. Safe to call from any goroutine.
+func (c *Client) currentAccessToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.accessToken
+}
+
+// authTransport is defined here so NewClient can reference it; the full
+// RoundTrip implementation lands in Task 5.
+type authTransport struct {
+	base   http.RoundTripper
+	client *Client
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.base.RoundTrip(req)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,57 @@
+package tradestation
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewClient_DefaultsToTestEnvironment(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	if c.apiBase != "https://sim-api.tradestation.com" {
+		t.Errorf("apiBase = %q, want sim-api", c.apiBase)
+	}
+}
+
+func TestNewClient_ProductionEnvironment(t *testing.T) {
+	c := NewClient(Production, "id", "secret", "refresh")
+	if c.apiBase != "https://api.tradestation.com" {
+		t.Errorf("apiBase = %q, want api", c.apiBase)
+	}
+}
+
+func TestNewClient_StoresCredentials(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	if c.clientID != "id" || c.clientSecret != "secret" || c.refreshToken != "refresh" {
+		t.Errorf("credentials not stored: got %q/%q/%q", c.clientID, c.clientSecret, c.refreshToken)
+	}
+}
+
+func TestWithRefreshTokenRotate_StoresCallback(t *testing.T) {
+	called := false
+	c := NewClient(Test, "id", "secret", "refresh",
+		WithRefreshTokenRotate(func(string) { called = true }))
+	if c.onRotate == nil {
+		t.Fatal("onRotate not set")
+	}
+	c.onRotate("new")
+	if !called {
+		t.Error("callback not invoked")
+	}
+}
+
+func TestWithHTTPClient_PreservesCustomTransport(t *testing.T) {
+	custom := &http.Client{Transport: &fakeRoundTripper{}}
+	c := NewClient(Test, "id", "secret", "refresh", WithHTTPClient(custom))
+	// Our transport wraps theirs — unwrap once and assert.
+	at, ok := c.http.Transport.(*authTransport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *authTransport", c.http.Transport)
+	}
+	if _, ok := at.base.(*fakeRoundTripper); !ok {
+		t.Errorf("base transport is %T, want *fakeRoundTripper", at.base)
+	}
+}
+
+type fakeRoundTripper struct{}
+
+func (f *fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,12 @@
 package tradestation
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -55,3 +60,116 @@ func TestWithHTTPClient_PreservesCustomTransport(t *testing.T) {
 type fakeRoundTripper struct{}
 
 func (f *fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func TestDoJSON_GetHappyPath(t *testing.T) {
+	var gotMethod, gotPath, gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"value":"hello"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	var out struct{ Value string }
+	if err := c.doJSON(context.Background(), "GET", "/ping", nil, nil, &out); err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/ping" || gotAccept != "application/json" {
+		t.Errorf("request shape wrong: %s %s accept=%q", gotMethod, gotPath, gotAccept)
+	}
+	if out.Value != "hello" {
+		t.Errorf("Value = %q, want hello", out.Value)
+	}
+}
+
+func TestDoJSON_PostEncodesBody(t *testing.T) {
+	var gotCT string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	body := map[string]int{"n": 42}
+	if err := c.doJSON(context.Background(), "POST", "/x", nil, body, nil); err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if string(gotBody) != `{"n":42}` {
+		t.Errorf("body = %q, want %q", gotBody, `{"n":42}`)
+	}
+}
+
+func TestDoJSON_EncodesQueryParams(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	q := url.Values{}
+	q.Set("interval", "1")
+	q.Set("unit", "Minute")
+	if err := c.doJSON(context.Background(), "GET", "/y", q, nil, nil); err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if gotQuery != "interval=1&unit=Minute" {
+		t.Errorf("query = %q, want interval=1&unit=Minute", gotQuery)
+	}
+}
+
+func TestDoJSON_ErrorResponse_ParsesMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"Error":"BadRequest","Message":"invalid symbol"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	err := c.doJSON(context.Background(), "GET", "/z", nil, nil, nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 400 || apiErr.Message != "invalid symbol" {
+		t.Errorf("got %+v", apiErr)
+	}
+}
+
+func TestDoJSON_ErrorResponse_FallsBackToRawBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte("oops"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	err := c.doJSON(context.Background(), "GET", "/", nil, nil, nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 500 || string(apiErr.RawBody) != "oops" {
+		t.Errorf("got %+v", apiErr)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -268,3 +268,126 @@ func TestRefreshAccessToken_ErrorResponse(t *testing.T) {
 		t.Errorf("StatusCode = %d", apiErr.StatusCode)
 	}
 }
+
+func TestAuthTransport_AttachesBearer(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	c.mu.Lock()
+	c.accessToken = "initial-token"
+	c.mu.Unlock()
+
+	c.doJSON(context.Background(), "GET", "/", nil, nil, nil)
+	if gotAuth != "Bearer initial-token" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestAuthTransport_RefreshOn401ThenRetry(t *testing.T) {
+	// Token endpoint: returns new-token
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"access_token":"new-token","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	// API endpoint: 401 on first call with "initial", 200 with "new-token".
+	var apiCalls int
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		auth := r.Header.Get("Authorization")
+		if auth == "Bearer new-token" {
+			w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		w.WriteHeader(401)
+	}))
+	defer apiSrv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = apiSrv.URL
+	c.tokenURL = tokenSrv.URL
+	c.mu.Lock()
+	c.accessToken = "initial"
+	c.mu.Unlock()
+
+	var out struct{ Ok bool }
+	if err := c.doJSON(context.Background(), "GET", "/", nil, nil, &out); err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if !out.Ok {
+		t.Error("response not decoded")
+	}
+	if apiCalls != 2 {
+		t.Errorf("api calls = %d, want 2", apiCalls)
+	}
+}
+
+func TestAuthTransport_SecondRequestAlso401_ReturnsError(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"access_token":"new","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	var apiCalls int
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		w.WriteHeader(401)
+	}))
+	defer apiSrv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = apiSrv.URL
+	c.tokenURL = tokenSrv.URL
+
+	err := c.doJSON(context.Background(), "GET", "/", nil, nil, nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 401 {
+		t.Errorf("want *APIError 401, got %v", err)
+	}
+	if apiCalls != 2 {
+		t.Errorf("api calls = %d, want 2 (original + one retry)", apiCalls)
+	}
+}
+
+func TestAuthTransport_BodyReplayOn401(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"access_token":"new","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	var bodies []string
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		if r.Header.Get("Authorization") == "Bearer new" {
+			w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(401)
+	}))
+	defer apiSrv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = apiSrv.URL
+	c.tokenURL = tokenSrv.URL
+
+	body := map[string]string{"hello": "world"}
+	if err := c.doJSON(context.Background(), "POST", "/", nil, body, nil); err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("bodies seen = %d, want 2", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("body not replayed: first=%q second=%q", bodies[0], bodies[1])
+	}
+	if bodies[0] != `{"hello":"world"}` {
+		t.Errorf("body shape wrong: %q", bodies[0])
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -173,3 +173,98 @@ func TestDoJSON_ErrorResponse_FallsBackToRawBody(t *testing.T) {
 		t.Errorf("got %+v", apiErr)
 	}
 }
+
+func TestRefreshAccessToken_HappyPath(t *testing.T) {
+	var gotForm url.Values
+	var gotCT string
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		r.ParseForm()
+		gotForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"new-access","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.tokenURL = tokenSrv.URL
+
+	if err := c.refreshAccessToken(context.Background()); err != nil {
+		t.Fatalf("refreshAccessToken: %v", err)
+	}
+	if c.currentAccessToken() != "new-access" {
+		t.Errorf("accessToken = %q, want new-access", c.currentAccessToken())
+	}
+	if gotCT != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q", gotCT)
+	}
+	if gotForm.Get("grant_type") != "refresh_token" ||
+		gotForm.Get("client_id") != "id" ||
+		gotForm.Get("client_secret") != "secret" ||
+		gotForm.Get("refresh_token") != "refresh" {
+		t.Errorf("form wrong: %v", gotForm)
+	}
+}
+
+func TestRefreshAccessToken_RotatesRefreshToken(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"new-access","refresh_token":"rotated","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	var rotated string
+	c := NewClient(Test, "id", "secret", "refresh",
+		WithRefreshTokenRotate(func(s string) { rotated = s }))
+	c.tokenURL = tokenSrv.URL
+
+	if err := c.refreshAccessToken(context.Background()); err != nil {
+		t.Fatalf("refreshAccessToken: %v", err)
+	}
+	if rotated != "rotated" {
+		t.Errorf("onRotate received %q, want rotated", rotated)
+	}
+	c.mu.Lock()
+	rt := c.refreshToken
+	c.mu.Unlock()
+	if rt != "rotated" {
+		t.Errorf("in-memory refresh token = %q, want rotated", rt)
+	}
+}
+
+func TestRefreshAccessToken_DoesNotCallRotateWhenSameToken(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"access_token":"new","refresh_token":"refresh","expires_in":1200}`))
+	}))
+	defer tokenSrv.Close()
+
+	called := false
+	c := NewClient(Test, "id", "secret", "refresh",
+		WithRefreshTokenRotate(func(string) { called = true }))
+	c.tokenURL = tokenSrv.URL
+
+	c.refreshAccessToken(context.Background())
+	if called {
+		t.Error("onRotate should not fire when refresh token unchanged")
+	}
+}
+
+func TestRefreshAccessToken_ErrorResponse(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"Error":"invalid_grant","Message":"refresh token expired"}`))
+	}))
+	defer tokenSrv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.tokenURL = tokenSrv.URL
+
+	err := c.refreshAccessToken(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d", apiErr.StatusCode)
+	}
+}

--- a/cmd/authorize/main.go
+++ b/cmd/authorize/main.go
@@ -28,7 +28,7 @@ const (
 	authorizeURL      = "https://signin.tradestation.com/authorize"
 	tokenURL          = "https://signin.tradestation.com/oauth/token"
 	audience          = "https://api.tradestation.com"
-	defaultRedirect   = "http://localhost:8080/callback"
+	defaultRedirect   = "http://localhost:8080"
 	defaultScopes     = "openid offline_access MarketData ReadAccount Trade profile"
 	defaultRefreshSSM = "/tradestation/refresh-token"
 )
@@ -65,7 +65,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("bind :8080: %v", err)
 	}
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
 		q := r.URL.Query()
 		if got := q.Get("state"); got != state {
 			err := fmt.Errorf("state mismatch: got %q, want %q", got, state)

--- a/cmd/authorize/main.go
+++ b/cmd/authorize/main.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+const (
+	authorizeURL      = "https://signin.tradestation.com/authorize"
+	tokenURL          = "https://signin.tradestation.com/oauth/token"
+	audience          = "https://api.tradestation.com"
+	defaultRedirect   = "http://localhost:3000/callback"
+	defaultScopes     = "openid offline_access MarketData ReadAccount Trade profile"
+	defaultRefreshSSM = "/tradestation/refresh-token"
+)
+
+func main() {
+	idParam := flag.String("id", "/tradestation/client-id", "SSM parameter name for client ID")
+	secretParam := flag.String("secret", "/tradestation/client-secret", "SSM parameter name for client secret")
+	refreshParam := flag.String("refresh", defaultRefreshSSM, "SSM parameter name to write refresh token to")
+	scopes := flag.String("scopes", defaultScopes, "OAuth scopes (space-separated)")
+	flag.Parse()
+
+	profile := os.Getenv("AWS_PROFILE")
+	if profile == "" {
+		profile = "joe-prod"
+	}
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
+	if err != nil {
+		log.Fatalf("load aws config (profile=%s): %v", profile, err)
+	}
+	ssmClient := ssm.NewFromConfig(cfg)
+
+	clientID := mustReadSSM(ctx, ssmClient, *idParam)
+	clientSecret := mustReadSSM(ctx, ssmClient, *secretParam)
+
+	state := randomState()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	srv := &http.Server{Addr: ":3000", Handler: mux}
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if got := q.Get("state"); got != state {
+			err := fmt.Errorf("state mismatch: got %q, want %q", got, state)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			errCh <- err
+			return
+		}
+		if errStr := q.Get("error"); errStr != "" {
+			desc := q.Get("error_description")
+			err := fmt.Errorf("authorize error: %s %s", errStr, desc)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			errCh <- err
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			err := fmt.Errorf("no code in callback")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			errCh <- err
+			return
+		}
+		fmt.Fprintln(w, "<html><body><h2>TradeStation authorization complete.</h2><p>You can close this tab.</p></body></html>")
+		codeCh <- code
+	})
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	authURL := authorizeURL + "?" + url.Values{
+		"response_type": {"code"},
+		"client_id":     {clientID},
+		"audience":      {audience},
+		"redirect_uri":  {defaultRedirect},
+		"scope":         {*scopes},
+		"state":         {state},
+	}.Encode()
+
+	fmt.Println("Opening browser for TradeStation authorization...")
+	fmt.Println("If it doesn't open, visit this URL manually:")
+	fmt.Println(authURL)
+	_ = openBrowser(authURL)
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		log.Fatalf("authorize: %v", err)
+	case <-time.After(5 * time.Minute):
+		log.Fatalf("authorize: timed out waiting for callback")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	srv.Shutdown(shutdownCtx)
+
+	tokenResp, err := exchangeCode(ctx, clientID, clientSecret, code)
+	if err != nil {
+		log.Fatalf("exchange code: %v", err)
+	}
+	if tokenResp.RefreshToken == "" {
+		log.Fatalf("no refresh_token in response — did you include the 'offline_access' scope?")
+	}
+
+	writeSSM(ctx, ssmClient, *refreshParam, tokenResp.RefreshToken)
+	fmt.Printf("Wrote refresh token to SSM parameter %s\n", *refreshParam)
+}
+
+func mustReadSSM(ctx context.Context, c *ssm.Client, name string) string {
+	out, err := c.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(name),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		log.Fatalf("read %s: %v", name, err)
+	}
+	return aws.ToString(out.Parameter.Value)
+}
+
+func writeSSM(ctx context.Context, c *ssm.Client, name, value string) {
+	_, err := c.PutParameter(ctx, &ssm.PutParameterInput{
+		Name:      aws.String(name),
+		Value:     aws.String(value),
+		Type:      ssmtypes.ParameterTypeSecureString,
+		Overwrite: aws.Bool(true),
+	})
+	if err != nil {
+		log.Fatalf("write %s: %v", name, err)
+	}
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+	TokenType    string `json:"token_type"`
+}
+
+func exchangeCode(ctx context.Context, clientID, clientSecret, code string) (*tokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", defaultRedirect)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("token endpoint: status %d", resp.StatusCode)
+	}
+
+	var out tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func randomState() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func openBrowser(u string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", u).Start()
+	case "linux":
+		return exec.Command("xdg-open", u).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", u).Start()
+	}
+	return fmt.Errorf("unsupported platform")
+}

--- a/cmd/authorize/main.go
+++ b/cmd/authorize/main.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -58,7 +60,11 @@ func main() {
 	errCh := make(chan error, 1)
 
 	mux := http.NewServeMux()
-	srv := &http.Server{Addr: ":3000", Handler: mux}
+	srv := &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", ":3000")
+	if err != nil {
+		log.Fatalf("bind :3000: %v", err)
+	}
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if got := q.Get("state"); got != state {
@@ -86,7 +92,7 @@ func main() {
 	})
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 		}
 	}()
@@ -181,8 +187,9 @@ func exchangeCode(ctx context.Context, clientID, clientSecret, code string) (*to
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("token endpoint: status %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token endpoint: status %d: %s", resp.StatusCode, body)
 	}
 
 	var out tokenResponse

--- a/cmd/authorize/main.go
+++ b/cmd/authorize/main.go
@@ -28,7 +28,7 @@ const (
 	authorizeURL      = "https://signin.tradestation.com/authorize"
 	tokenURL          = "https://signin.tradestation.com/oauth/token"
 	audience          = "https://api.tradestation.com"
-	defaultRedirect   = "http://localhost:3000/callback"
+	defaultRedirect   = "http://localhost:8080/callback"
 	defaultScopes     = "openid offline_access MarketData ReadAccount Trade profile"
 	defaultRefreshSSM = "/tradestation/refresh-token"
 )
@@ -61,9 +61,9 @@ func main() {
 
 	mux := http.NewServeMux()
 	srv := &http.Server{Handler: mux}
-	ln, err := net.Listen("tcp", ":3000")
+	ln, err := net.Listen("tcp", ":8080")
 	if err != nil {
-		log.Fatalf("bind :3000: %v", err)
+		log.Fatalf("bind :8080: %v", err)
 	}
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/cmd/envgen/main.go
+++ b/cmd/envgen/main.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	idParam := flag.String("id", "/tradestation/client-id", "SSM parameter name for client ID")
 	secretParam := flag.String("secret", "/tradestation/client-secret", "SSM parameter name for client secret")
+	refreshParam := flag.String("refresh", "/tradestation/refresh-token", "SSM parameter name for refresh token")
 	out := flag.String("out", ".env", "output file path")
 	flag.Parse()
 
@@ -30,7 +31,7 @@ func main() {
 	}
 
 	resp, err := ssm.NewFromConfig(cfg).GetParameters(ctx, &ssm.GetParametersInput{
-		Names:          []string{*idParam, *secretParam},
+		Names:          []string{*idParam, *secretParam, *refreshParam},
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
@@ -45,8 +46,9 @@ func main() {
 		values[aws.ToString(p.Name)] = aws.ToString(p.Value)
 	}
 
-	body := fmt.Sprintf("TRADESTATION_CLIENT_ID=%s\nTRADESTATION_CLIENT_SECRET=%s\n",
-		values[*idParam], values[*secretParam])
+	body := fmt.Sprintf(
+		"TRADESTATION_CLIENT_ID=%s\nTRADESTATION_CLIENT_SECRET=%s\nTRADESTATION_REFRESH_TOKEN=%s\n",
+		values[*idParam], values[*secretParam], values[*refreshParam])
 
 	if err := os.WriteFile(*out, []byte(body), 0o600); err != nil {
 		log.Fatalf("write %s: %v", *out, err)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,17 @@
+package tradestation
+
+import "fmt"
+
+// APIError is returned when TradeStation responds with a non-2xx status.
+type APIError struct {
+	StatusCode int
+	Message    string
+	RawBody    []byte
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("tradestation: %d %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("tradestation: %d", e.StatusCode)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,35 @@
+package tradestation
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAPIError_Error_WithMessage(t *testing.T) {
+	e := &APIError{StatusCode: 429, Message: "rate limited"}
+	got := e.Error()
+	want := "tradestation: 429 rate limited"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIError_Error_WithoutMessage(t *testing.T) {
+	e := &APIError{StatusCode: 500}
+	got := e.Error()
+	want := "tradestation: 500"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIError_ErrorsAs(t *testing.T) {
+	var err error = &APIError{StatusCode: 404, Message: "not found"}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatal("errors.As failed")
+	}
+	if apiErr.StatusCode != 404 {
+		t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/jkim-mlops/tradestation-go
 go 1.25.5
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.14 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2/config v1.32.14
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4
+)
+
+require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
@@ -13,7 +17,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -100,6 +100,15 @@ func TestIntegration_GetQuote_Multiple(t *testing.T) {
 	if len(quotes) != len(syms) {
 		t.Errorf("got %d quotes, want %d", len(quotes), len(syms))
 	}
+	got := make(map[string]bool, len(quotes))
+	for _, q := range quotes {
+		got[q.Symbol] = true
+	}
+	for _, s := range syms {
+		if !got[s] {
+			t.Errorf("missing quote for %s", s)
+		}
+	}
 }
 
 func TestIntegration_RefreshPath(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package tradestation
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func integrationClient(t *testing.T) *Client {
+	t.Helper()
+	id := os.Getenv("TRADESTATION_CLIENT_ID")
+	secret := os.Getenv("TRADESTATION_CLIENT_SECRET")
+	rt := os.Getenv("TRADESTATION_REFRESH_TOKEN")
+	if id == "" || secret == "" || rt == "" {
+		t.Skip("TRADESTATION_CLIENT_ID / _SECRET / _REFRESH_TOKEN not set; skipping integration tests")
+	}
+	return NewClient(Test, id, secret, rt)
+}
+
+func TestIntegration_GetBars_Daily(t *testing.T) {
+	c := integrationClient(t)
+	svc := &MarketDataService{client: c}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	bars, err := svc.GetBars(ctx, "AAPL", GetBarsParams{
+		Interval: 1, Unit: BarUnitDaily, BarsBack: 5,
+	})
+	if err != nil {
+		t.Fatalf("GetBars: %v", err)
+	}
+	if len(bars) == 0 {
+		t.Fatal("no bars returned")
+	}
+	for i, b := range bars {
+		if b.High < b.Low {
+			t.Errorf("bar %d: High %v < Low %v", i, b.High, b.Low)
+		}
+		if b.TotalVolume < 0 {
+			t.Errorf("bar %d: negative volume %d", i, b.TotalVolume)
+		}
+	}
+	for i := 1; i < len(bars); i++ {
+		if !bars[i].TimeStamp.After(bars[i-1].TimeStamp) {
+			t.Errorf("bars not strictly increasing: %d=%v, %d=%v", i-1, bars[i-1].TimeStamp, i, bars[i].TimeStamp)
+		}
+	}
+}
+
+func TestIntegration_GetBars_Minute(t *testing.T) {
+	c := integrationClient(t)
+	svc := &MarketDataService{client: c}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	bars, err := svc.GetBars(ctx, "SPY", GetBarsParams{
+		Interval: 5, Unit: BarUnitMinute, BarsBack: 20,
+	})
+	if err != nil {
+		t.Fatalf("GetBars: %v", err)
+	}
+	if len(bars) == 0 {
+		t.Fatal("no bars returned")
+	}
+}
+
+func TestIntegration_GetQuote_Single(t *testing.T) {
+	c := integrationClient(t)
+	svc := &MarketDataService{client: c}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	quotes, err := svc.GetQuote(ctx, []string{"AAPL"})
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if len(quotes) != 1 || quotes[0].Symbol != "AAPL" {
+		t.Errorf("quotes = %+v", quotes)
+	}
+}
+
+func TestIntegration_GetQuote_Multiple(t *testing.T) {
+	c := integrationClient(t)
+	svc := &MarketDataService{client: c}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	syms := []string{"AAPL", "MSFT", "GOOGL", "SPY", "QQQ"}
+	quotes, err := svc.GetQuote(ctx, syms)
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if len(quotes) != len(syms) {
+		t.Errorf("got %d quotes, want %d", len(quotes), len(syms))
+	}
+}
+
+func TestIntegration_RefreshPath(t *testing.T) {
+	c := integrationClient(t)
+	// Force a refresh on the next call by clearing the in-memory access token.
+	c.mu.Lock()
+	c.accessToken = ""
+	c.mu.Unlock()
+
+	svc := &MarketDataService{client: c}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := svc.GetQuote(ctx, []string{"AAPL"}); err != nil {
+		t.Fatalf("GetQuote after forced refresh: %v", err)
+	}
+	if c.currentAccessToken() == "" {
+		t.Error("access token not populated after refresh")
+	}
+}
+
+func TestIntegration_BogusSymbol(t *testing.T) {
+	c := integrationClient(t)
+	svc := &MarketDataService{client: c}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := svc.GetBars(ctx, "NOSUCHSYMBOL_XXX", GetBarsParams{
+		Interval: 1, Unit: BarUnitDaily, BarsBack: 1,
+	})
+	if err == nil {
+		t.Fatal("expected error for bogus symbol")
+	}
+	// We accept any error shape here - the actual TradeStation behavior may be
+	// 4xx, may be 200 with empty bars. Adjust once integration run reveals truth.
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,14 +3,39 @@
 package tradestation
 
 import (
+	"bufio"
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
 
+func loadEnvFile(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if os.Getenv(k) == "" {
+			os.Setenv(k, v)
+		}
+	}
+}
+
 func integrationClient(t *testing.T) *Client {
 	t.Helper()
+	loadEnvFile(".env")
 	id := os.Getenv("TRADESTATION_CLIENT_ID")
 	secret := os.Getenv("TRADESTATION_CLIENT_SECRET")
 	rt := os.Getenv("TRADESTATION_REFRESH_TOKEN")

--- a/market_data.go
+++ b/market_data.go
@@ -2,8 +2,10 @@ package tradestation
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 type MarketDataService struct {
@@ -48,7 +50,22 @@ func (s *MarketDataService) GetBars(ctx context.Context, symbol string, params G
 }
 
 func (s *MarketDataService) GetQuote(ctx context.Context, symbols []string) ([]Quote, error) {
-	panic("not implemented") // Task 7
+	if len(symbols) == 0 {
+		return nil, errors.New("tradestation: GetQuote requires at least one symbol")
+	}
+	if len(symbols) > 50 {
+		return nil, errors.New("tradestation: GetQuote supports at most 50 symbols per request")
+	}
+
+	path := "/v3/marketdata/quotes/" + strings.Join(symbols, ",")
+
+	var resp struct {
+		Quotes []Quote `json:"Quotes"`
+	}
+	if err := s.client.doJSON(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Quotes, nil
 }
 
 func (s *MarketDataService) GetOptionsChain(symbol string) (*OptionsChain, error) {

--- a/market_data.go
+++ b/market_data.go
@@ -1,19 +1,58 @@
 package tradestation
 
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
 type MarketDataService struct {
 	client *Client
 }
 
-func (s *MarketDataService) GetBars(symbol string, interval string, barsBack int) ([]Bar, error) {
-	panic("not implemented")
+type BarUnit string
+
+const (
+	BarUnitMinute  BarUnit = "Minute"
+	BarUnitDaily   BarUnit = "Daily"
+	BarUnitWeekly  BarUnit = "Weekly"
+	BarUnitMonthly BarUnit = "Monthly"
+)
+
+type GetBarsParams struct {
+	Interval  int // 1-1440; must be 1 for Daily/Weekly/Monthly
+	Unit      BarUnit
+	BarsBack  int    // optional; when 0, uses StartDate
+	StartDate string // optional ISO8601
 }
 
-func (s *MarketDataService) GetQuote(symbols []string) ([]Quote, error) {
-	panic("not implemented")
+func (s *MarketDataService) GetBars(ctx context.Context, symbol string, params GetBarsParams) ([]Bar, error) {
+	q := url.Values{}
+	q.Set("interval", strconv.Itoa(params.Interval))
+	q.Set("unit", string(params.Unit))
+	if params.BarsBack > 0 {
+		q.Set("barsback", strconv.Itoa(params.BarsBack))
+	}
+	if params.StartDate != "" {
+		q.Set("startdate", params.StartDate)
+	}
+
+	var resp struct {
+		Bars []Bar `json:"Bars"`
+	}
+	path := "/v3/marketdata/barcharts/" + url.PathEscape(symbol)
+	if err := s.client.doJSON(ctx, "GET", path, q, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Bars, nil
+}
+
+func (s *MarketDataService) GetQuote(ctx context.Context, symbols []string) ([]Quote, error) {
+	panic("not implemented") // Task 7
 }
 
 func (s *MarketDataService) GetOptionsChain(symbol string) (*OptionsChain, error) {
-	panic("not implemented")
+	panic("not implemented") // Phase 2D: streaming-only in the spec
 }
 
 func (s *MarketDataService) StreamBars(symbol string, interval string) (<-chan Bar, error) {

--- a/market_data_test.go
+++ b/market_data_test.go
@@ -62,3 +62,49 @@ func TestGetBars_WithStartDate(t *testing.T) {
 		t.Errorf("query = %q, want %q", gotQuery, want)
 	}
 }
+
+func TestGetQuote_RequestShape(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"Quotes":[{"Symbol":"AAPL","Last":150.5},{"Symbol":"MSFT","Last":300.1}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &MarketDataService{client: c}
+
+	quotes, err := svc.GetQuote(context.Background(), []string{"AAPL", "MSFT"})
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if gotPath != "/v3/marketdata/quotes/AAPL,MSFT" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if len(quotes) != 2 || quotes[0].Symbol != "AAPL" || quotes[1].Last != 300.1 {
+		t.Errorf("quotes decoded wrong: %+v", quotes)
+	}
+}
+
+func TestGetQuote_EmptyRejected(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &MarketDataService{client: c}
+	_, err := svc.GetQuote(context.Background(), nil)
+	if err == nil {
+		t.Error("want error for empty symbols")
+	}
+}
+
+func TestGetQuote_TooManyRejected(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &MarketDataService{client: c}
+	syms := make([]string, 51)
+	for i := range syms {
+		syms[i] = "X"
+	}
+	_, err := svc.GetQuote(context.Background(), syms)
+	if err == nil {
+		t.Error("want error for >50 symbols")
+	}
+}

--- a/market_data_test.go
+++ b/market_data_test.go
@@ -1,0 +1,64 @@
+package tradestation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetBars_RequestShape(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"Bars":[{"Open":1,"High":2,"Low":0.5,"Close":1.5,"TotalVolume":100}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &MarketDataService{client: c}
+
+	bars, err := svc.GetBars(context.Background(), "AAPL", GetBarsParams{
+		Interval: 1, Unit: BarUnitDaily, BarsBack: 10,
+	})
+	if err != nil {
+		t.Fatalf("GetBars: %v", err)
+	}
+	if gotPath != "/v3/marketdata/barcharts/AAPL" {
+		t.Errorf("path = %q", gotPath)
+	}
+	// url.Values.Encode sorts keys alphabetically.
+	if gotQuery != "barsback=10&interval=1&unit=Daily" {
+		t.Errorf("query = %q", gotQuery)
+	}
+	if len(bars) != 1 || bars[0].Open != 1 {
+		t.Errorf("bars decoded wrong: %+v", bars)
+	}
+}
+
+func TestGetBars_WithStartDate(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Write([]byte(`{"Bars":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &MarketDataService{client: c}
+
+	_, err := svc.GetBars(context.Background(), "MSFT", GetBarsParams{
+		Interval: 1, Unit: BarUnitMinute, StartDate: "2026-01-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GetBars: %v", err)
+	}
+	want := "interval=1&startdate=2026-01-01T00%3A00%3A00Z&unit=Minute"
+	if gotQuery != want {
+		t.Errorf("query = %q, want %q", gotQuery, want)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1,42 +1,88 @@
 package tradestation
 
-import "time"
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+// StringFloat64 unmarshals from both JSON strings ("1.5") and numbers (1.5).
+type StringFloat64 float64
+
+func (f *StringFloat64) UnmarshalJSON(data []byte) error {
+	var n float64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = StringFloat64(n)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return err
+	}
+	*f = StringFloat64(n)
+	return nil
+}
+
+// StringInt64 unmarshals from both JSON strings ("100") and numbers (100).
+type StringInt64 int64
+
+func (i *StringInt64) UnmarshalJSON(data []byte) error {
+	var n int64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*i = StringInt64(n)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*i = StringInt64(n)
+	return nil
+}
 
 // MarketData types
 
 type Bar struct {
-	High            float64   `json:"High"`
-	Low             float64   `json:"Low"`
-	Open            float64   `json:"Open"`
-	Close           float64   `json:"Close"`
-	TimeStamp       time.Time `json:"TimeStamp"`
-	TotalVolume     int64     `json:"TotalVolume"`
-	DownTicks       int64     `json:"DownTicks"`
-	DownVolume      int64     `json:"DownVolume"`
-	OpenInterest    int64     `json:"OpenInterest"`
-	IsRealtime      bool      `json:"IsRealtime"`
-	TotalTicks      int64     `json:"TotalTicks"`
-	UnchangedTicks  int64     `json:"UnchangedTicks"`
-	UnchangedVolume int64     `json:"UnchangedVolume"`
-	UpTicks         int64     `json:"UpTicks"`
-	UpVolume        int64     `json:"UpVolume"`
-	Epoch           int64     `json:"Epoch"`
-	BarStatus       string    `json:"BarStatus"`
+	High            StringFloat64 `json:"High"`
+	Low             StringFloat64 `json:"Low"`
+	Open            StringFloat64 `json:"Open"`
+	Close           StringFloat64 `json:"Close"`
+	TimeStamp       time.Time     `json:"TimeStamp"`
+	TotalVolume     StringInt64   `json:"TotalVolume"`
+	DownTicks       StringInt64   `json:"DownTicks"`
+	DownVolume      StringInt64   `json:"DownVolume"`
+	OpenInterest    StringInt64   `json:"OpenInterest"`
+	IsRealtime      bool          `json:"IsRealtime"`
+	TotalTicks      StringInt64   `json:"TotalTicks"`
+	UnchangedTicks  StringInt64   `json:"UnchangedTicks"`
+	UnchangedVolume StringInt64   `json:"UnchangedVolume"`
+	UpTicks         StringInt64   `json:"UpTicks"`
+	UpVolume        StringInt64   `json:"UpVolume"`
+	Epoch           StringInt64   `json:"Epoch"`
+	BarStatus       string        `json:"BarStatus"`
 }
 
 type Quote struct {
-	Symbol            string  `json:"Symbol"`
-	Ask               float64 `json:"Ask"`
-	AskSize           int64   `json:"AskSize"`
-	Bid               float64 `json:"Bid"`
-	BidSize           int64   `json:"BidSize"`
-	Last              float64 `json:"Last"`
-	LastSize          int64   `json:"LastSize"`
-	Volume            int64   `json:"Volume"`
-	Close             float64 `json:"Close"`
-	High52Week        float64 `json:"High52Week"`
-	Low52Week         float64 `json:"Low52Week"`
-	DailyOpenInterest int64   `json:"DailyOpenInterest"`
+	Symbol            string        `json:"Symbol"`
+	Ask               StringFloat64 `json:"Ask"`
+	AskSize           StringInt64   `json:"AskSize"`
+	Bid               StringFloat64 `json:"Bid"`
+	BidSize           StringInt64   `json:"BidSize"`
+	Last              StringFloat64 `json:"Last"`
+	LastSize          StringInt64   `json:"LastSize"`
+	Volume            StringInt64   `json:"Volume"`
+	Close             StringFloat64 `json:"Close"`
+	High52Week        StringFloat64 `json:"High52Week"`
+	Low52Week         StringFloat64 `json:"Low52Week"`
+	DailyOpenInterest StringInt64   `json:"DailyOpenInterest"`
 }
 
 type OptionsChain struct {
@@ -49,23 +95,23 @@ type OptionsExpiration struct {
 }
 
 type OptionsStrike struct {
-	StrikePrice float64     `json:"StrikePrice"`
-	Call        *OptionsLeg `json:"Call"`
-	Put         *OptionsLeg `json:"Put"`
+	StrikePrice StringFloat64 `json:"StrikePrice"`
+	Call        *OptionsLeg   `json:"Call"`
+	Put         *OptionsLeg   `json:"Put"`
 }
 
 type OptionsLeg struct {
-	Symbol            string  `json:"Symbol"`
-	Ask               float64 `json:"Ask"`
-	Bid               float64 `json:"Bid"`
-	Last              float64 `json:"Last"`
-	Volume            int64   `json:"Volume"`
-	OpenInterest      int64   `json:"OpenInterest"`
-	ImpliedVolatility float64 `json:"ImpliedVolatility"`
-	Delta             float64 `json:"Delta"`
-	Gamma             float64 `json:"Gamma"`
-	Theta             float64 `json:"Theta"`
-	Vega              float64 `json:"Vega"`
+	Symbol            string        `json:"Symbol"`
+	Ask               StringFloat64 `json:"Ask"`
+	Bid               StringFloat64 `json:"Bid"`
+	Last              StringFloat64 `json:"Last"`
+	Volume            StringInt64   `json:"Volume"`
+	OpenInterest      StringInt64   `json:"OpenInterest"`
+	ImpliedVolatility StringFloat64 `json:"ImpliedVolatility"`
+	Delta             StringFloat64 `json:"Delta"`
+	Gamma             StringFloat64 `json:"Gamma"`
+	Theta             StringFloat64 `json:"Theta"`
+	Vega              StringFloat64 `json:"Vega"`
 }
 
 // Brokerage types
@@ -77,50 +123,50 @@ type Account struct {
 }
 
 type Position struct {
-	AccountID         string  `json:"AccountID"`
-	Symbol            string  `json:"Symbol"`
-	Quantity          int64   `json:"Quantity"`
-	AveragePrice      float64 `json:"AveragePrice"`
-	Last              float64 `json:"Last"`
-	MarketValue       float64 `json:"MarketValue"`
-	UnrealizedPnL     float64 `json:"UnrealizedPL"`
-	LongShort         string  `json:"LongShort"`
-	AssetType         string  `json:"AssetType"`
-	ConversionRate    float64 `json:"ConversionRate"`
-	InitialMargin     float64 `json:"InitialMargin"`
-	MaintenanceMargin float64 `json:"MaintenanceMargin"`
-	TotalCost         float64 `json:"TotalCost"`
-	Timestamp         string  `json:"Timestamp"`
+	AccountID         string        `json:"AccountID"`
+	Symbol            string        `json:"Symbol"`
+	Quantity          StringInt64   `json:"Quantity"`
+	AveragePrice      StringFloat64 `json:"AveragePrice"`
+	Last              StringFloat64 `json:"Last"`
+	MarketValue       StringFloat64 `json:"MarketValue"`
+	UnrealizedPnL     StringFloat64 `json:"UnrealizedPL"`
+	LongShort         string        `json:"LongShort"`
+	AssetType         string        `json:"AssetType"`
+	ConversionRate    StringFloat64 `json:"ConversionRate"`
+	InitialMargin     StringFloat64 `json:"InitialMargin"`
+	MaintenanceMargin StringFloat64 `json:"MaintenanceMargin"`
+	TotalCost         StringFloat64 `json:"TotalCost"`
+	Timestamp         string        `json:"Timestamp"`
 }
 
 type Balance struct {
-	AccountID     string  `json:"AccountID"`
-	CashBalance   float64 `json:"CashBalance"`
-	BuyingPower   float64 `json:"BuyingPower"`
-	Equity        float64 `json:"Equity"`
-	MarketValue   float64 `json:"MarketValue"`
-	RealizedPnL   float64 `json:"RealizedPL"`
-	UnrealizedPnL float64 `json:"UnrealizedPL"`
+	AccountID     string        `json:"AccountID"`
+	CashBalance   StringFloat64 `json:"CashBalance"`
+	BuyingPower   StringFloat64 `json:"BuyingPower"`
+	Equity        StringFloat64 `json:"Equity"`
+	MarketValue   StringFloat64 `json:"MarketValue"`
+	RealizedPnL   StringFloat64 `json:"RealizedPL"`
+	UnrealizedPnL StringFloat64 `json:"UnrealizedPL"`
 }
 
 // Order Execution types
 
 type Order struct {
-	OrderID        string  `json:"OrderID"`
-	AccountID      string  `json:"AccountID"`
-	Symbol         string  `json:"Symbol"`
-	Quantity       int64   `json:"Quantity"`
-	FilledQuantity int64   `json:"FilledQuantity"`
-	OrderType      string  `json:"OrderType"`
-	LimitPrice     float64 `json:"LimitPrice"`
-	StopPrice      float64 `json:"StopPrice"`
-	Side           string  `json:"Side"`
-	Status         string  `json:"Status"`
-	Duration       string  `json:"Duration"`
-	FilledPrice    float64 `json:"FilledPrice"`
-	OpenedDateTime string  `json:"OpenedDateTime"`
-	ClosedDateTime string  `json:"ClosedDateTime"`
-	TimeInForce    string  `json:"TimeInForce"`
+	OrderID        string        `json:"OrderID"`
+	AccountID      string        `json:"AccountID"`
+	Symbol         string        `json:"Symbol"`
+	Quantity       StringInt64   `json:"Quantity"`
+	FilledQuantity StringInt64   `json:"FilledQuantity"`
+	OrderType      string        `json:"OrderType"`
+	LimitPrice     StringFloat64 `json:"LimitPrice"`
+	StopPrice      StringFloat64 `json:"StopPrice"`
+	Side           string        `json:"Side"`
+	Status         string        `json:"Status"`
+	Duration       string        `json:"Duration"`
+	FilledPrice    StringFloat64 `json:"FilledPrice"`
+	OpenedDateTime string        `json:"OpenedDateTime"`
+	ClosedDateTime string        `json:"ClosedDateTime"`
+	TimeInForce    string        `json:"TimeInForce"`
 }
 
 type OrderRequest struct {


### PR DESCRIPTION
## Summary                                                                                                       
                                                                                                                   
  - **OAuth client** with reactive refresh-on-401 via `authTransport` (`http.RoundTripper` wrapper), automatic     
  bearer token attachment, and request body replay on retry                                                        
  - **MarketData service** with `GetBars` (historical OHLCV) and `GetQuote` (snapshot quotes) hitting              
  TradeStation's v3 REST API                                                                                       
  - **`StringFloat64` / `StringInt64` types** to handle TradeStation's string-encoded JSON numerics                
  - **`cmd/authorize`** — interactive OAuth authorization code flow CLI that writes the refresh token to AWS SSM   
  - **`cmd/envgen`** — pulls client-id, client-secret, and refresh-token from SSM into `.env`                      
  - **26 unit tests** (httptest-based) covering auth transport, doJSON, APIError parsing, and service methods      
  - **6 integration tests** (opt-in via `//go:build integration`) verified against the TradeStation sandbox        
                                                                                                                   
  ## Test plan                                                                                                     
                                                                                                                   
  - [x] `go test ./...` — 26 unit tests pass                                                                       
  - [x] `go test -tags=integration ./... -v` — 6 integration tests pass against `sim-api.tradestation.com`         
  - [x] `go vet ./...` — clean                                                                                     
  - [x] `go build ./...` — clean (library + both CLIs)                                                             
  - [x] Verify `cmd/authorize` flow on a fresh machine (requires TradeStation API key + AWS credentials) 