### PR TITLE
feat: streaming endpoints (StreamOrders/OrdersByID/Positions/Bars) + generic StreamEvent[T]

### DIFF
--- a/brokerage.go
+++ b/brokerage.go
@@ -211,6 +211,30 @@ func (s *BrokerageService) StreamOrders(
 	return openStream[Order](ctx, s.client, openReq, cfg)
 }
 
+func (s *BrokerageService) StreamOrdersByID(
+	ctx context.Context,
+	accountIDs, orderIDs []string,
+	opts ...StreamOption,
+) (<-chan OrderEvent, error) {
+	if err := validateAccountIDs(accountIDs); err != nil {
+		return nil, err
+	}
+	if err := validateOrderIDs(orderIDs); err != nil {
+		return nil, err
+	}
+	cfg := defaultStreamOpts()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	path := "/v3/brokerage/stream/accounts/" + strings.Join(accountIDs, ",") +
+		"/orders/" + strings.Join(orderIDs, ",")
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", s.client.apiBase+path, nil)
+	}
+	return openStream[Order](ctx, s.client, openReq, cfg)
+}
+
 func (s *BrokerageService) historicalOrdersLoop(
 	ctx context.Context,
 	basePath string,

--- a/brokerage.go
+++ b/brokerage.go
@@ -235,6 +235,26 @@ func (s *BrokerageService) StreamOrdersByID(
 	return openStream[Order](ctx, s.client, openReq, cfg)
 }
 
+func (s *BrokerageService) StreamPositions(
+	ctx context.Context,
+	accountIDs []string,
+	opts ...StreamOption,
+) (<-chan PositionEvent, error) {
+	if err := validateAccountIDs(accountIDs); err != nil {
+		return nil, err
+	}
+	cfg := defaultStreamOpts()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	path := "/v3/brokerage/stream/accounts/" + strings.Join(accountIDs, ",") + "/positions"
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", s.client.apiBase+path, nil)
+	}
+	return openStream[Position](ctx, s.client, openReq, cfg)
+}
+
 func (s *BrokerageService) historicalOrdersLoop(
 	ctx context.Context,
 	basePath string,

--- a/brokerage.go
+++ b/brokerage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -188,6 +189,26 @@ func (s *BrokerageService) GetHistoricalOrdersByID(
 	basePath := "/v3/brokerage/accounts/" + strings.Join(accountIDs, ",") +
 		"/historicalorders/" + strings.Join(orderIDs, ",")
 	return s.historicalOrdersLoop(ctx, basePath, since, opts)
+}
+
+func (s *BrokerageService) StreamOrders(
+	ctx context.Context,
+	accountIDs []string,
+	opts ...StreamOption,
+) (<-chan OrderEvent, error) {
+	if err := validateAccountIDs(accountIDs); err != nil {
+		return nil, err
+	}
+	cfg := defaultStreamOpts()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	path := "/v3/brokerage/stream/accounts/" + strings.Join(accountIDs, ",") + "/orders"
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", s.client.apiBase+path, nil)
+	}
+	return openStream[Order](ctx, s.client, openReq, cfg)
 }
 
 func (s *BrokerageService) historicalOrdersLoop(

--- a/brokerage_stream_test.go
+++ b/brokerage_stream_test.go
@@ -1,0 +1,74 @@
+package tradestation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStreamOrders_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		f := w.(http.Flusher)
+		w.Write([]byte(`{"OrderID":"o1","AccountID":"123","Status":"Open"}` + "\n"))
+		f.Flush()
+		w.Write([]byte(`{"StreamStatus":"EndSnapshot"}` + "\n"))
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &BrokerageService{client: c}
+
+	events, err := svc.StreamOrders(context.Background(), []string{"123", "456"}, WithoutReconnect())
+	if err != nil {
+		t.Fatalf("StreamOrders: %v", err)
+	}
+
+	var gotOrder, gotSnapshot bool
+	for ev := range events {
+		switch {
+		case ev.Err != nil:
+			t.Fatalf("err: %v", ev.Err)
+		case ev.Data != nil:
+			if ev.Data.OrderID != "o1" || ev.Data.AccountID != "123" {
+				t.Errorf("order decoded wrong: %+v", *ev.Data)
+			}
+			gotOrder = true
+		case ev.Status == StreamStatusEndSnapshot:
+			gotSnapshot = true
+		}
+	}
+	if gotPath != "/v3/brokerage/stream/accounts/123,456/orders" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !gotOrder {
+		t.Error("no order event received")
+	}
+	if !gotSnapshot {
+		t.Error("no EndSnapshot received")
+	}
+}
+
+func TestStreamOrders_ValidationRejectsEmpty(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &BrokerageService{client: c}
+	if _, err := svc.StreamOrders(context.Background(), nil); err == nil {
+		t.Error("want error for empty accountIDs")
+	}
+}
+
+func TestStreamOrders_ValidationRejectsTooMany(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &BrokerageService{client: c}
+	ids := make([]string, 26)
+	for i := range ids {
+		ids[i] = "a"
+	}
+	if _, err := svc.StreamOrders(context.Background(), ids); err == nil {
+		t.Error("want error for >25 accountIDs")
+	}
+}

--- a/brokerage_stream_test.go
+++ b/brokerage_stream_test.go
@@ -112,3 +112,48 @@ func TestStreamOrdersByID_ValidationRejectsEmptyOrderIDs(t *testing.T) {
 		t.Error("want error for empty orderIDs")
 	}
 }
+
+func TestStreamPositions_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		f := w.(http.Flusher)
+		w.Write([]byte(`{"AccountID":"123","Symbol":"AAPL","Quantity":"10"}` + "\n"))
+		f.Flush()
+		w.Write([]byte(`{"StreamStatus":"EndSnapshot"}` + "\n"))
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &BrokerageService{client: c}
+
+	events, err := svc.StreamPositions(context.Background(), []string{"123"}, WithoutReconnect())
+	if err != nil {
+		t.Fatalf("StreamPositions: %v", err)
+	}
+	var gotPosition bool
+	for ev := range events {
+		if ev.Err != nil {
+			t.Fatalf("err: %v", ev.Err)
+		}
+		if ev.Data != nil && ev.Data.Symbol == "AAPL" {
+			gotPosition = true
+		}
+	}
+	if gotPath != "/v3/brokerage/stream/accounts/123/positions" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !gotPosition {
+		t.Error("no position event received")
+	}
+}
+
+func TestStreamPositions_ValidationRejectsEmpty(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &BrokerageService{client: c}
+	if _, err := svc.StreamPositions(context.Background(), nil); err == nil {
+		t.Error("want error for empty accountIDs")
+	}
+}

--- a/brokerage_stream_test.go
+++ b/brokerage_stream_test.go
@@ -72,3 +72,43 @@ func TestStreamOrders_ValidationRejectsTooMany(t *testing.T) {
 		t.Error("want error for >25 accountIDs")
 	}
 }
+
+func TestStreamOrdersByID_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		f := w.(http.Flusher)
+		w.Write([]byte(`{"OrderID":"o1","AccountID":"123"}` + "\n"))
+		f.Flush()
+		w.Write([]byte(`{"StreamStatus":"EndSnapshot"}` + "\n"))
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &BrokerageService{client: c}
+
+	events, err := svc.StreamOrdersByID(
+		context.Background(),
+		[]string{"123"},
+		[]string{"o1", "o2"},
+		WithoutReconnect(),
+	)
+	if err != nil {
+		t.Fatalf("StreamOrdersByID: %v", err)
+	}
+	for range events {
+	}
+	if gotPath != "/v3/brokerage/stream/accounts/123/orders/o1,o2" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestStreamOrdersByID_ValidationRejectsEmptyOrderIDs(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &BrokerageService{client: c}
+	if _, err := svc.StreamOrdersByID(context.Background(), []string{"123"}, nil); err == nil {
+		t.Error("want error for empty orderIDs")
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -336,6 +336,36 @@ func TestIntegration_StreamOrders(t *testing.T) {
 	}
 }
 
+func TestIntegration_StreamPositions(t *testing.T) {
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, err := c.Brokerage().StreamPositions(ctx, ids, WithoutReconnect())
+	if err != nil {
+		t.Fatalf("StreamPositions: %v", err)
+	}
+
+	var gotSnapshot bool
+	for ev := range events {
+		switch {
+		case ev.Err != nil:
+			t.Fatalf("stream error: %v", ev.Err)
+		case ev.Data != nil:
+			t.Logf("position: %+v", *ev.Data)
+		case ev.Status == StreamStatusEndSnapshot:
+			t.Logf("status: EndSnapshot")
+			gotSnapshot = true
+			cancel()
+		}
+	}
+	if !gotSnapshot {
+		t.Error("no EndSnapshot received")
+	}
+}
+
 func TestIntegration_StreamQuotes(t *testing.T) {
 	c := integrationClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/integration_test.go
+++ b/integration_test.go
@@ -302,6 +302,40 @@ func TestIntegration_GetHistoricalOrders(t *testing.T) {
 	dumpJSON(t, "historicalOrders", resp)
 }
 
+func TestIntegration_StreamOrders(t *testing.T) {
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, err := c.Brokerage().StreamOrders(ctx, ids, WithoutReconnect())
+	if err != nil {
+		t.Fatalf("StreamOrders: %v", err)
+	}
+
+	var gotSnapshot bool
+	for ev := range events {
+		switch {
+		case ev.Err != nil:
+			t.Fatalf("stream error: %v", ev.Err)
+		case ev.Data != nil:
+			t.Logf("order: %+v", *ev.Data)
+		case ev.Status == StreamStatusEndSnapshot:
+			t.Logf("status: EndSnapshot")
+			gotSnapshot = true
+			cancel()
+		default:
+			if ev.Status != "" {
+				t.Logf("status: %s", ev.Status)
+			}
+		}
+	}
+	if !gotSnapshot {
+		t.Error("no EndSnapshot received")
+	}
+}
+
 func TestIntegration_StreamQuotes(t *testing.T) {
 	c := integrationClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/integration_test.go
+++ b/integration_test.go
@@ -318,9 +318,9 @@ func TestIntegration_StreamQuotes(t *testing.T) {
 		switch {
 		case ev.Err != nil:
 			t.Fatalf("stream error: %v", ev.Err)
-		case ev.Quote != nil:
-			t.Logf("quote: %+v", *ev.Quote)
-			got[ev.Quote.Symbol] = *ev.Quote
+		case ev.Data != nil:
+			t.Logf("quote: %+v", *ev.Data)
+			got[ev.Data.Symbol] = *ev.Data
 		case ev.Status != "":
 			t.Logf("status: %s", ev.Status)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -366,6 +366,47 @@ func TestIntegration_StreamPositions(t *testing.T) {
 	}
 }
 
+func TestIntegration_StreamBars(t *testing.T) {
+	c := integrationClient(t)
+
+	const wantBars = 5
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, err := c.MarketData().StreamBars(
+		ctx,
+		"SPY",
+		StreamBarsParams{Interval: 1, Unit: BarUnitMinute, BarsBack: wantBars},
+		WithoutReconnect(),
+	)
+	if err != nil {
+		t.Fatalf("StreamBars: %v", err)
+	}
+
+	// Bar streams don't emit EndSnapshot (unlike orders/positions/quotes).
+	// We exit after receiving the requested BarsBack historical bars.
+	var bars int
+	for ev := range events {
+		switch {
+		case ev.Err != nil:
+			t.Fatalf("stream error: %v", ev.Err)
+		case ev.Data != nil:
+			t.Logf("bar: %+v", *ev.Data)
+			bars++
+		case ev.Status != "":
+			t.Logf("status: %s", ev.Status)
+		}
+		if bars >= wantBars {
+			cancel()
+			break
+		}
+	}
+	if bars < wantBars {
+		t.Errorf("received %d bars, want >= %d", bars, wantBars)
+	}
+}
+
 func TestIntegration_StreamQuotes(t *testing.T) {
 	c := integrationClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/integration_test.go
+++ b/integration_test.go
@@ -407,6 +407,54 @@ func TestIntegration_StreamBars(t *testing.T) {
 	}
 }
 
+func TestIntegration_StreamOrdersByID(t *testing.T) {
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	getCtx, getCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer getCancel()
+	resp, err := c.Brokerage().GetOrders(getCtx, ids)
+	if err != nil {
+		t.Fatalf("GetOrders: %v", err)
+	}
+	if len(resp.Orders) == 0 {
+		t.Skip("no orders on sandbox — cannot test StreamOrdersByID")
+	}
+	orderID := resp.Orders[0].OrderID
+	accountID := resp.Orders[0].AccountID
+	t.Logf("streaming order %s on account %s", orderID, accountID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, err := c.Brokerage().StreamOrdersByID(
+		ctx,
+		[]string{accountID},
+		[]string{orderID},
+		WithoutReconnect(),
+	)
+	if err != nil {
+		t.Fatalf("StreamOrdersByID: %v", err)
+	}
+
+	var gotSnapshot bool
+	for ev := range events {
+		switch {
+		case ev.Err != nil:
+			t.Fatalf("stream error: %v", ev.Err)
+		case ev.Data != nil:
+			t.Logf("order: %+v", *ev.Data)
+		case ev.Status == StreamStatusEndSnapshot:
+			t.Logf("status: EndSnapshot")
+			gotSnapshot = true
+			cancel()
+		}
+	}
+	if !gotSnapshot {
+		t.Error("no EndSnapshot received")
+	}
+}
+
 func TestIntegration_StreamQuotes(t *testing.T) {
 	c := integrationClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/market_data.go
+++ b/market_data.go
@@ -3,6 +3,7 @@ package tradestation
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -78,8 +79,50 @@ func (s *MarketDataService) GetOptionsChain(symbol string) (*OptionsChain, error
 	panic("not implemented") // Phase 2D: streaming-only in the spec
 }
 
-func (s *MarketDataService) StreamBars(symbol string, interval string) (<-chan Bar, error) {
-	panic("not implemented")
+type StreamBarsParams struct {
+	Interval        int     // 1..1440; must be 1 for Daily/Weekly/Monthly
+	Unit            BarUnit // "Minute" | "Daily" | "Weekly" | "Monthly"
+	BarsBack        int     // optional; historical bars included before live updates
+	SessionTemplate string  // optional; e.g. "USEQPreAndPost"
+}
+
+func (s *MarketDataService) StreamBars(
+	ctx context.Context,
+	symbol string,
+	params StreamBarsParams,
+	opts ...StreamOption,
+) (<-chan BarEvent, error) {
+	if symbol == "" {
+		return nil, errors.New("tradestation: StreamBars requires a symbol")
+	}
+	if params.Interval < 1 || params.Interval > 1440 {
+		return nil, errors.New("tradestation: StreamBars interval must be between 1 and 1440")
+	}
+	if params.Unit != BarUnitMinute && params.Interval != 1 {
+		return nil, fmt.Errorf("tradestation: StreamBars requires interval=1 for %s bars", params.Unit)
+	}
+
+	cfg := defaultStreamOpts()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	q := url.Values{}
+	q.Set("interval", strconv.Itoa(params.Interval))
+	q.Set("unit", string(params.Unit))
+	if params.BarsBack > 0 {
+		q.Set("barsback", strconv.Itoa(params.BarsBack))
+	}
+	if params.SessionTemplate != "" {
+		q.Set("sessiontemplate", params.SessionTemplate)
+	}
+
+	path := "/v3/marketdata/stream/barcharts/" + url.PathEscape(symbol)
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		u := s.client.apiBase + path + "?" + q.Encode()
+		return http.NewRequestWithContext(ctx, "GET", u, nil)
+	}
+	return openStream[Bar](ctx, s.client, openReq, cfg)
 }
 
 func (s *MarketDataService) StreamQuotes(

--- a/market_data.go
+++ b/market_data.go
@@ -93,7 +93,6 @@ func (s *MarketDataService) StreamQuotes(
 	if len(symbols) > 50 {
 		return nil, errors.New("tradestation: StreamQuotes supports at most 50 symbols per request")
 	}
-
 	cfg := defaultStreamOpts()
 	for _, o := range opts {
 		o(&cfg)
@@ -103,27 +102,5 @@ func (s *MarketDataService) StreamQuotes(
 	openReq := func(ctx context.Context) (*http.Request, error) {
 		return http.NewRequestWithContext(ctx, "GET", s.client.apiBase+path, nil)
 	}
-
-	// Synchronous first attempt so initial connect errors (4xx/5xx) return here
-	// rather than through the channel. authTransport handles 401 refresh-and-retry.
-	req, err := openReq(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := s.client.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		defer resp.Body.Close()
-		return nil, parseAPIError(resp)
-	}
-
-	raw := make(chan streamEvent)
-	events := make(chan QuoteEvent)
-
-	go s.client.runStreamFromResp(ctx, resp, openReq, raw, cfg)
-	go pumpEvents[Quote](raw, events)
-
-	return events, nil
+	return openStream[Quote](ctx, s.client, openReq, cfg)
 }

--- a/market_data.go
+++ b/market_data.go
@@ -2,9 +2,7 @@ package tradestation
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -84,15 +82,6 @@ func (s *MarketDataService) StreamBars(symbol string, interval string) (<-chan B
 	panic("not implemented")
 }
 
-// QuoteEvent is a single event on a quote stream. Exactly one of Quote, Status,
-// or Err is populated per event. The event channel closes after a terminal
-// event (Err populated, or clean termination).
-type QuoteEvent struct {
-	Quote  *Quote
-	Status StreamStatus
-	Err    error
-}
-
 func (s *MarketDataService) StreamQuotes(
 	ctx context.Context,
 	symbols []string,
@@ -134,26 +123,7 @@ func (s *MarketDataService) StreamQuotes(
 	events := make(chan QuoteEvent)
 
 	go s.client.runStreamFromResp(ctx, resp, openReq, raw, cfg)
-	go pumpQuoteEvents(raw, events)
+	go pumpEvents[Quote](raw, events)
 
 	return events, nil
-}
-
-func pumpQuoteEvents(in <-chan streamEvent, out chan<- QuoteEvent) {
-	defer close(out)
-	for ev := range in {
-		switch {
-		case ev.Err != nil:
-			out <- QuoteEvent{Err: ev.Err}
-		case ev.Status != "":
-			out <- QuoteEvent{Status: ev.Status}
-		default:
-			var q Quote
-			if err := json.Unmarshal(ev.Raw, &q); err != nil {
-				out <- QuoteEvent{Err: fmt.Errorf("tradestation: decode quote: %w", err)}
-				continue
-			}
-			out <- QuoteEvent{Quote: &q}
-		}
-	}
 }

--- a/market_data_test.go
+++ b/market_data_test.go
@@ -247,6 +247,112 @@ func TestStreamQuotes_HeartbeatsFiltered(t *testing.T) {
 	}
 }
 
+func TestStreamBars_HappyPath(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		f := w.(http.Flusher)
+		w.Write([]byte(`{"Open":"100","High":"101","Low":"99","Close":"100.5","TotalVolume":"1000","TimeStamp":"2026-04-19T15:00:00Z"}` + "\n"))
+		f.Flush()
+		w.Write([]byte(`{"StreamStatus":"EndSnapshot"}` + "\n"))
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &MarketDataService{client: c}
+
+	events, err := svc.StreamBars(
+		context.Background(),
+		"AAPL",
+		StreamBarsParams{Interval: 1, Unit: BarUnitMinute, BarsBack: 5},
+		WithoutReconnect(),
+	)
+	if err != nil {
+		t.Fatalf("StreamBars: %v", err)
+	}
+
+	var gotBar bool
+	for ev := range events {
+		if ev.Err != nil {
+			t.Fatalf("err: %v", ev.Err)
+		}
+		if ev.Data != nil && ev.Data.Close == 100.5 {
+			gotBar = true
+		}
+	}
+	if gotPath != "/v3/marketdata/stream/barcharts/AAPL" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotQuery != "barsback=5&interval=1&unit=Minute" {
+		t.Errorf("query = %q", gotQuery)
+	}
+	if !gotBar {
+		t.Error("no bar event received")
+	}
+}
+
+func TestStreamBars_SessionTemplate(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.(http.Flusher).Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+	svc := &MarketDataService{client: c}
+
+	events, err := svc.StreamBars(
+		context.Background(),
+		"SPY",
+		StreamBarsParams{Interval: 5, Unit: BarUnitMinute, SessionTemplate: "USEQPreAndPost"},
+		WithoutReconnect(),
+	)
+	if err != nil {
+		t.Fatalf("StreamBars: %v", err)
+	}
+	for range events {
+	}
+	if gotQuery != "interval=5&sessiontemplate=USEQPreAndPost&unit=Minute" {
+		t.Errorf("query = %q", gotQuery)
+	}
+}
+
+func TestStreamBars_ValidationRejectsEmptySymbol(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &MarketDataService{client: c}
+	_, err := svc.StreamBars(context.Background(), "", StreamBarsParams{Interval: 1, Unit: BarUnitMinute})
+	if err == nil {
+		t.Error("want error for empty symbol")
+	}
+}
+
+func TestStreamBars_ValidationRejectsBadInterval(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &MarketDataService{client: c}
+	_, err := svc.StreamBars(context.Background(), "AAPL", StreamBarsParams{Interval: 0, Unit: BarUnitMinute})
+	if err == nil {
+		t.Error("want error for interval=0")
+	}
+	_, err = svc.StreamBars(context.Background(), "AAPL", StreamBarsParams{Interval: 1441, Unit: BarUnitMinute})
+	if err == nil {
+		t.Error("want error for interval=1441")
+	}
+}
+
+func TestStreamBars_ValidationRejectsNonMinuteIntervalGtOne(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	svc := &MarketDataService{client: c}
+	_, err := svc.StreamBars(context.Background(), "AAPL", StreamBarsParams{Interval: 2, Unit: BarUnitDaily})
+	if err == nil {
+		t.Error("want error for Daily with interval>1")
+	}
+}
+
 func TestStreamQuotes_ConnectErrorReturnsImmediately(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/market_data_test.go
+++ b/market_data_test.go
@@ -139,9 +139,9 @@ func TestStreamQuotes_HappyPath(t *testing.T) {
 		switch {
 		case ev.Err != nil:
 			t.Fatalf("unexpected error: %v", ev.Err)
-		case ev.Quote != nil:
-			if ev.Quote.Symbol != "AAPL" || ev.Quote.Last != 150.5 {
-				t.Errorf("quote decoded wrong: %+v", *ev.Quote)
+		case ev.Data != nil:
+			if ev.Data.Symbol != "AAPL" || ev.Data.Last != 150.5 {
+				t.Errorf("quote decoded wrong: %+v", *ev.Data)
 			}
 			quoteSeen = true
 		case ev.Status != "":
@@ -235,8 +235,8 @@ func TestStreamQuotes_HeartbeatsFiltered(t *testing.T) {
 		if ev.Err != nil {
 			t.Fatalf("unexpected error: %v", ev.Err)
 		}
-		if ev.Quote != nil {
-			got = append(got, *ev.Quote)
+		if ev.Data != nil {
+			got = append(got, *ev.Data)
 		}
 	}
 	if len(got) != 2 {

--- a/orders.go
+++ b/orders.go
@@ -15,7 +15,3 @@ func (s *OrderService) ReplaceOrder(orderID string, req OrderRequest) (*Order, e
 func (s *OrderService) CancelOrder(orderID string) error {
 	panic("not implemented")
 }
-
-func (s *OrderService) StreamOrderUpdates(accountID string) (<-chan Order, error) {
-	panic("not implemented")
-}

--- a/stream.go
+++ b/stream.go
@@ -165,6 +165,42 @@ type streamEvent struct {
 	Err    error
 }
 
+// StreamEvent is the generic event shape emitted by streaming services.
+// Exactly one of Data, Status, or Err is populated per event.
+type StreamEvent[T any] struct {
+	Data   *T
+	Status StreamStatus
+	Err    error
+}
+
+type (
+	QuoteEvent    = StreamEvent[Quote]
+	BarEvent      = StreamEvent[Bar]
+	OrderEvent    = StreamEvent[Order]
+	PositionEvent = StreamEvent[Position]
+)
+
+// pumpEvents reads raw stream events, decodes data payloads into T, and
+// forwards typed events to out. Closes out when in closes.
+func pumpEvents[T any](in <-chan streamEvent, out chan<- StreamEvent[T]) {
+	defer close(out)
+	for ev := range in {
+		switch {
+		case ev.Err != nil:
+			out <- StreamEvent[T]{Err: ev.Err}
+		case ev.Status != "":
+			out <- StreamEvent[T]{Status: ev.Status}
+		default:
+			var v T
+			if err := json.Unmarshal(ev.Raw, &v); err != nil {
+				out <- StreamEvent[T]{Err: fmt.Errorf("tradestation: decode %T: %w", v, err)}
+				continue
+			}
+			out <- StreamEvent[T]{Data: &v}
+		}
+	}
+}
+
 // runStreamOnce opens one connection and drains it. Return semantics:
 //
 //	terminal != nil  → do not reconnect (currently only *StreamError)

--- a/stream.go
+++ b/stream.go
@@ -180,6 +180,35 @@ type (
 	PositionEvent = StreamEvent[Position]
 )
 
+// openStream performs the synchronous first connect so connect-time 4xx/5xx
+// surface via the error return (not the channel), then wires the runner + pump
+// goroutines. Returns the typed event channel.
+func openStream[T any](
+	ctx context.Context,
+	client *Client,
+	openReq func(ctx context.Context) (*http.Request, error),
+	cfg streamOpts,
+) (<-chan StreamEvent[T], error) {
+	req, err := openReq(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return nil, parseAPIError(resp)
+	}
+
+	raw := make(chan streamEvent)
+	events := make(chan StreamEvent[T])
+	go client.runStreamFromResp(ctx, resp, openReq, raw, cfg)
+	go pumpEvents[T](raw, events)
+	return events, nil
+}
+
 // pumpEvents reads raw stream events, decodes data payloads into T, and
 // forwards typed events to out. Closes out when in closes.
 func pumpEvents[T any](in <-chan streamEvent, out chan<- StreamEvent[T]) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -617,6 +617,74 @@ func TestRunStreamFromResp_UsesPreOpenedResponse(t *testing.T) {
 	}
 }
 
+type fakePayload struct {
+	Name  string `json:"Name"`
+	Value int    `json:"Value"`
+}
+
+func TestPumpEvents_DecodesData(t *testing.T) {
+	in := make(chan streamEvent, 1)
+	out := make(chan StreamEvent[fakePayload], 1)
+
+	in <- streamEvent{Raw: []byte(`{"Name":"foo","Value":42}`)}
+	close(in)
+
+	pumpEvents[fakePayload](in, out)
+
+	ev, ok := <-out
+	if !ok {
+		t.Fatal("no event received")
+	}
+	if ev.Err != nil || ev.Status != "" {
+		t.Fatalf("unexpected non-data event: %+v", ev)
+	}
+	if ev.Data == nil || ev.Data.Name != "foo" || ev.Data.Value != 42 {
+		t.Errorf("decoded wrong: %+v", ev.Data)
+	}
+	if _, more := <-out; more {
+		t.Error("channel should be closed")
+	}
+}
+
+func TestPumpEvents_ForwardsStatus(t *testing.T) {
+	in := make(chan streamEvent, 1)
+	out := make(chan StreamEvent[fakePayload], 1)
+	in <- streamEvent{Status: StreamStatusEndSnapshot}
+	close(in)
+	pumpEvents[fakePayload](in, out)
+	ev := <-out
+	if ev.Status != StreamStatusEndSnapshot {
+		t.Errorf("Status = %q", ev.Status)
+	}
+}
+
+func TestPumpEvents_ForwardsErr(t *testing.T) {
+	in := make(chan streamEvent, 1)
+	out := make(chan StreamEvent[fakePayload], 1)
+	in <- streamEvent{Err: errors.New("boom")}
+	close(in)
+	pumpEvents[fakePayload](in, out)
+	ev := <-out
+	if ev.Err == nil || ev.Err.Error() != "boom" {
+		t.Errorf("Err = %v", ev.Err)
+	}
+}
+
+func TestPumpEvents_DecodeFailureBecomesErrEvent(t *testing.T) {
+	in := make(chan streamEvent, 1)
+	out := make(chan StreamEvent[fakePayload], 1)
+	in <- streamEvent{Raw: []byte(`{not json`)}
+	close(in)
+	pumpEvents[fakePayload](in, out)
+	ev := <-out
+	if ev.Err == nil {
+		t.Fatal("want decode error")
+	}
+	if !strings.Contains(ev.Err.Error(), "decode") {
+		t.Errorf("Err should mention decode: %v", ev.Err)
+	}
+}
+
 func TestRunStreamFromResp_ReconnectsOnEOF(t *testing.T) {
 	var calls int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -617,6 +617,58 @@ func TestRunStreamFromResp_UsesPreOpenedResponse(t *testing.T) {
 	}
 }
 
+func TestOpenStream_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunkedWrite(w, `{"Name":"hello","Value":1}`+"\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", srv.URL, nil)
+	}
+	cfg := defaultStreamOpts()
+	cfg.reconnect = false
+
+	events, err := openStream[fakePayload](context.Background(), c, openReq, cfg)
+	if err != nil {
+		t.Fatalf("openStream: %v", err)
+	}
+	ev, ok := <-events
+	if !ok {
+		t.Fatal("no events received")
+	}
+	if ev.Data == nil || ev.Data.Name != "hello" {
+		t.Errorf("decoded wrong: %+v", ev.Data)
+	}
+}
+
+func TestOpenStream_ConnectErrorReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"Error":"BadRequest","Message":"bad path"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	openReq := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", srv.URL, nil)
+	}
+
+	_, err := openStream[fakePayload](context.Background(), c, openReq, defaultStreamOpts())
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *APIError
+	if !errors.As(err, &ae) || ae.StatusCode != http.StatusBadRequest {
+		t.Errorf("want *APIError 400, got %v", err)
+	}
+}
+
 type fakePayload struct {
 	Name  string `json:"Name"`
 	Value int    `json:"Value"`


### PR DESCRIPTION
## Summary

- Adds four streaming endpoints on top of the existing streaming infrastructure:
  - `BrokerageService.StreamOrders(accountIDs, opts...)`
  - `BrokerageService.StreamOrdersByID(accountIDs, orderIDs, opts...)`
  - `BrokerageService.StreamPositions(accountIDs, opts...)`
  - `MarketDataService.StreamBars(symbol, StreamBarsParams{...}, opts...)` (replaces panic stub)
- Refactors the event shape into a generic `StreamEvent[T any]{Data, Status, Err}` with type aliases (`QuoteEvent`, `BarEvent`, `OrderEvent`, `PositionEvent`). Every stream method body is now ~18 lines.
- Extracts `openStream[T]` helper (synchronous first-connect + runner + pump) so all stream methods share wiring.
- Deletes the redundant `OrderService.StreamOrderUpdates` Phase-1 stub.

Closes #6.

## Breaking change

`QuoteEvent.Quote` → `QuoteEvent.Data` (now backed by `StreamEvent[Quote].Data`). Only internal caller was the integration test; updated here.

## Test Plan

- [x] `go test ./...` — all unit tests green
- [x] `go vet ./... && go build ./...` — clean
- [x] \`go test -tags=integration -run TestIntegration_Stream -v ./...\` (sandbox):
  - [x] `TestIntegration_StreamOrders` — EndSnapshot received
  - [x] `TestIntegration_StreamOrdersByID` — streamed live AAPL limit order (OrderID 947789944) + EndSnapshot
  - [x] `TestIntegration_StreamPositions` — got AAPL position + EndSnapshot
  - [x] `TestIntegration_StreamBars` — received 5 historical bars (bar streams don't emit EndSnapshot — test exits on BarsBack count)
  - [x] `TestIntegration_StreamQuotes` — regression check, still green

## Out of scope

Market depth streams and option streams. Shapes predicted in the design doc — easy to add when a consumer asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)