### PR TITLE
feat: order execution REST (issue #8)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -662,3 +662,128 @@ func TestIntegration_PlaceAndReplaceAndCancel(t *testing.T) {
 	}
 	t.Logf("replaced: %+v", replaced)
 }
+
+func TestIntegration_PlaceAndCancelOCOGroup(t *testing.T) {
+	requireOrderPlacementOptIn(t)
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	legA := OrderRequest{
+		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
+		OrderType: OrderTypeLimit, TradeAction: TradeActionBuy,
+		LimitPrice:  1, // won't fill
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	legB := legA
+	legB.LimitPrice = 2 // also won't fill; different price so distinguishable
+
+	group := OrderGroupRequest{Type: OrderGroupTypeOCO, Orders: []OrderRequest{legA, legB}}
+	resp, err := c.OrderExecution().PlaceOrderGroup(ctx, group)
+	if err != nil {
+		t.Fatalf("PlaceOrderGroup: %v", err)
+	}
+	t.Logf("placed: %+v, errors: %+v", resp.Orders, resp.Errors)
+	if len(resp.Orders) < 2 {
+		t.Fatalf("expected 2 orders, got %d (errors: %+v)", len(resp.Orders), resp.Errors)
+	}
+
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		for _, o := range resp.Orders {
+			if err := c.OrderExecution().CancelOrder(cctx, o.OrderID); err != nil {
+				t.Logf("cancel cleanup failed for %s: %v", o.OrderID, err)
+			}
+		}
+	}()
+
+	// Verify both visible in GetOrders.
+	orders, err := c.Brokerage().GetOrders(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetOrders: %v", err)
+	}
+	seen := make(map[string]bool)
+	for _, o := range orders.Orders {
+		for _, placed := range resp.Orders {
+			if o.OrderID == placed.OrderID {
+				seen[o.OrderID] = true
+				t.Logf("found order: %+v", o)
+			}
+		}
+	}
+	if len(seen) != len(resp.Orders) {
+		t.Errorf("saw %d of %d placed orders in GetOrders", len(seen), len(resp.Orders))
+	}
+}
+
+func TestIntegration_PlaceAndCancelBracketGroup(t *testing.T) {
+	requireOrderPlacementOptIn(t)
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	parent := OrderRequest{
+		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
+		OrderType: OrderTypeLimit, TradeAction: TradeActionBuy,
+		LimitPrice:  1, // won't fill
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	profit := OrderRequest{
+		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
+		OrderType: OrderTypeLimit, TradeAction: TradeActionSell,
+		LimitPrice:  500, // unreachable profit target
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	stop := OrderRequest{
+		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
+		OrderType: OrderTypeStopMarket, TradeAction: TradeActionSell,
+		StopPrice:   0.5, // unreachable stop
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+
+	group := OrderGroupRequest{
+		Type:   OrderGroupTypeBracket,
+		Orders: []OrderRequest{parent, profit, stop},
+	}
+	resp, err := c.OrderExecution().PlaceOrderGroup(ctx, group)
+	if err != nil {
+		t.Fatalf("PlaceOrderGroup: %v", err)
+	}
+	t.Logf("placed: %+v, errors: %+v", resp.Orders, resp.Errors)
+	if len(resp.Orders) < 3 {
+		t.Fatalf("expected 3 orders, got %d (errors: %+v)", len(resp.Orders), resp.Errors)
+	}
+
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		for _, o := range resp.Orders {
+			if err := c.OrderExecution().CancelOrder(cctx, o.OrderID); err != nil {
+				t.Logf("cancel cleanup failed for %s: %v", o.OrderID, err)
+			}
+		}
+	}()
+
+	// Verify all three visible in GetOrders.
+	orders, err := c.Brokerage().GetOrders(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetOrders: %v", err)
+	}
+	seen := make(map[string]bool)
+	for _, o := range orders.Orders {
+		for _, placed := range resp.Orders {
+			if o.OrderID == placed.OrderID {
+				seen[o.OrderID] = true
+				t.Logf("found order: %+v", o)
+			}
+		}
+	}
+	if len(seen) != len(resp.Orders) {
+		t.Errorf("saw %d of %d placed orders in GetOrders", len(seen), len(resp.Orders))
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -567,7 +567,7 @@ func TestIntegration_PlaceOrderConfirm(t *testing.T) {
 		OrderType:   OrderTypeLimit,
 		TradeAction: TradeActionBuy,
 		LimitPrice:  1, // far-below-market; preview only
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 	resp, err := c.OrderExecution().PlaceOrderConfirm(ctx, req)
 	if err != nil {
@@ -607,7 +607,7 @@ func TestIntegration_PlaceAndCancelOrder(t *testing.T) {
 		OrderType:   OrderTypeLimit,
 		TradeAction: TradeActionBuy,
 		LimitPrice:  1, // far-below-market, won't fill
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 	resp, err := c.OrderExecution().PlaceOrder(ctx, req)
 	if err != nil {
@@ -661,7 +661,7 @@ func TestIntegration_PlaceAndReplaceAndCancel(t *testing.T) {
 		OrderType:   OrderTypeLimit,
 		TradeAction: TradeActionBuy,
 		LimitPrice:  1,
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 	resp, err := c.OrderExecution().PlaceOrder(ctx, req)
 	if err != nil {
@@ -699,7 +699,7 @@ func TestIntegration_PlaceAndCancelOCOGroup(t *testing.T) {
 		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
 		OrderType: OrderTypeLimit, TradeAction: TradeActionBuy,
 		LimitPrice:  1, // won't fill
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 	legB := legA
 	legB.LimitPrice = 2 // also won't fill; different price so distinguishable
@@ -751,36 +751,32 @@ func TestIntegration_PlaceAndCancelBracketGroup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	parent := OrderRequest{
-		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
-		OrderType: OrderTypeLimit, TradeAction: TradeActionBuy,
-		LimitPrice:  1, // won't fill
-		TimeInForce: TimeInForce{Duration: DurationDay},
-	}
+	// TradeStation BRK groups are the exit OCO (profit + stop), both same
+	// side. The entry would be placed separately via OSO — not tested here.
 	profit := OrderRequest{
 		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
 		OrderType: OrderTypeLimit, TradeAction: TradeActionSell,
 		LimitPrice:  500, // unreachable profit target
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 	stop := OrderRequest{
 		AccountID: ids[0], Symbol: "AAPL", Quantity: 1,
 		OrderType: OrderTypeStopMarket, TradeAction: TradeActionSell,
 		StopPrice:   0.5, // unreachable stop
-		TimeInForce: TimeInForce{Duration: DurationDay},
+		TimeInForce: TimeInForce{Duration: DurationGTC},
 	}
 
 	group := OrderGroupRequest{
 		Type:   OrderGroupTypeBracket,
-		Orders: []OrderRequest{parent, profit, stop},
+		Orders: []OrderRequest{profit, stop},
 	}
 	resp, err := c.OrderExecution().PlaceOrderGroup(ctx, group)
 	if err != nil {
 		t.Fatalf("PlaceOrderGroup: %v", err)
 	}
 	t.Logf("placed: %+v, errors: %+v", resp.Orders, resp.Errors)
-	if len(resp.Orders) < 3 {
-		t.Fatalf("expected 3 orders, got %d (errors: %+v)", len(resp.Orders), resp.Errors)
+	if len(resp.Orders) < 2 {
+		t.Fatalf("expected 2 orders, got %d (errors: %+v)", len(resp.Orders), resp.Errors)
 	}
 
 	defer func() {

--- a/integration_test.go
+++ b/integration_test.go
@@ -559,3 +559,106 @@ func TestIntegration_PlaceOrderConfirm(t *testing.T) {
 		t.Logf("error: %+v", e)
 	}
 }
+
+// requireOrderPlacementOptIn skips unless the destructive-tests env var is set.
+func requireOrderPlacementOptIn(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TRADESTATION_INTEGRATION_PLACE_ORDERS") != "1" {
+		t.Skip("set TRADESTATION_INTEGRATION_PLACE_ORDERS=1 to run destructive order-placement tests")
+	}
+}
+
+func TestIntegration_PlaceAndCancelOrder(t *testing.T) {
+	requireOrderPlacementOptIn(t)
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req := OrderRequest{
+		AccountID:   ids[0],
+		Symbol:      "AAPL",
+		Quantity:    1,
+		OrderType:   OrderTypeLimit,
+		TradeAction: TradeActionBuy,
+		LimitPrice:  1, // far-below-market, won't fill
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	resp, err := c.OrderExecution().PlaceOrder(ctx, req)
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	t.Logf("placed: %+v, errors: %+v", resp.Orders, resp.Errors)
+	if len(resp.Orders) == 0 {
+		t.Fatalf("no order placed: errors=%+v", resp.Errors)
+	}
+	orderID := resp.Orders[0].OrderID
+
+	// Cleanup: cancel in defer so panics don't leak orders.
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		if err := c.OrderExecution().CancelOrder(cctx, orderID); err != nil {
+			t.Logf("cancel cleanup failed for %s: %v", orderID, err)
+		}
+	}()
+
+	// Verify order is visible via GetOrders.
+	orders, err := c.Brokerage().GetOrders(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetOrders: %v", err)
+	}
+	var found bool
+	for _, o := range orders.Orders {
+		if o.OrderID == orderID {
+			t.Logf("found order: %+v", o)
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("placed order %s not found in GetOrders", orderID)
+	}
+}
+
+func TestIntegration_PlaceAndReplaceAndCancel(t *testing.T) {
+	requireOrderPlacementOptIn(t)
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req := OrderRequest{
+		AccountID:   ids[0],
+		Symbol:      "AAPL",
+		Quantity:    1,
+		OrderType:   OrderTypeLimit,
+		TradeAction: TradeActionBuy,
+		LimitPrice:  1,
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	resp, err := c.OrderExecution().PlaceOrder(ctx, req)
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	if len(resp.Orders) == 0 {
+		t.Fatalf("no order placed: errors=%+v", resp.Errors)
+	}
+	orderID := resp.Orders[0].OrderID
+
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		if err := c.OrderExecution().CancelOrder(cctx, orderID); err != nil {
+			t.Logf("cancel cleanup failed for %s: %v", orderID, err)
+		}
+	}()
+
+	replaced, err := c.OrderExecution().ReplaceOrder(ctx, orderID, ReplaceOrderRequest{Quantity: 2})
+	if err != nil {
+		t.Fatalf("ReplaceOrder: %v", err)
+	}
+	t.Logf("replaced: %+v", replaced)
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -223,6 +223,30 @@ func fetchSandboxAccountIDs(t *testing.T, c *Client) []string {
 	return ids
 }
 
+// fetchSandboxEquityAccountIDs returns only accounts capable of equity orders
+// (AccountType Margin or Cash). Futures accounts can't accept AAPL/SPY orders
+// and will fail with "Invalid account for the asset type".
+func fetchSandboxEquityAccountIDs(t *testing.T, c *Client) []string {
+	t.Helper()
+	svc := &BrokerageService{client: c}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	accounts, err := svc.GetAccounts(ctx)
+	if err != nil {
+		t.Fatalf("fetch accounts: %v", err)
+	}
+	ids := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		if a.AccountType == "Margin" || a.AccountType == "Cash" {
+			ids = append(ids, a.AccountID)
+		}
+	}
+	if len(ids) == 0 {
+		t.Skip("no equity (Margin/Cash) accounts on sandbox — skipping dependent tests")
+	}
+	return ids
+}
+
 func TestIntegration_GetBalances(t *testing.T) {
 	c := integrationClient(t)
 	ids := fetchSandboxAccountIDs(t, c)
@@ -531,7 +555,7 @@ func TestIntegration_GetRoutes(t *testing.T) {
 
 func TestIntegration_PlaceOrderConfirm(t *testing.T) {
 	c := integrationClient(t)
-	ids := fetchSandboxAccountIDs(t, c)
+	ids := fetchSandboxEquityAccountIDs(t, c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -571,7 +595,7 @@ func requireOrderPlacementOptIn(t *testing.T) {
 func TestIntegration_PlaceAndCancelOrder(t *testing.T) {
 	requireOrderPlacementOptIn(t)
 	c := integrationClient(t)
-	ids := fetchSandboxAccountIDs(t, c)
+	ids := fetchSandboxEquityAccountIDs(t, c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -625,7 +649,7 @@ func TestIntegration_PlaceAndCancelOrder(t *testing.T) {
 func TestIntegration_PlaceAndReplaceAndCancel(t *testing.T) {
 	requireOrderPlacementOptIn(t)
 	c := integrationClient(t)
-	ids := fetchSandboxAccountIDs(t, c)
+	ids := fetchSandboxEquityAccountIDs(t, c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -666,7 +690,7 @@ func TestIntegration_PlaceAndReplaceAndCancel(t *testing.T) {
 func TestIntegration_PlaceAndCancelOCOGroup(t *testing.T) {
 	requireOrderPlacementOptIn(t)
 	c := integrationClient(t)
-	ids := fetchSandboxAccountIDs(t, c)
+	ids := fetchSandboxEquityAccountIDs(t, c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -722,7 +746,7 @@ func TestIntegration_PlaceAndCancelOCOGroup(t *testing.T) {
 func TestIntegration_PlaceAndCancelBracketGroup(t *testing.T) {
 	requireOrderPlacementOptIn(t)
 	c := integrationClient(t)
-	ids := fetchSandboxAccountIDs(t, c)
+	ids := fetchSandboxEquityAccountIDs(t, c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/integration_test.go
+++ b/integration_test.go
@@ -494,3 +494,68 @@ func TestIntegration_StreamQuotes(t *testing.T) {
 		}
 	}
 }
+
+func TestIntegration_GetActivationTriggers(t *testing.T) {
+	c := integrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	triggers, err := c.OrderExecution().GetActivationTriggers(ctx)
+	if err != nil {
+		t.Fatalf("GetActivationTriggers: %v", err)
+	}
+	for _, at := range triggers {
+		t.Logf("trigger: %+v", at)
+	}
+	if len(triggers) == 0 {
+		t.Error("no triggers returned")
+	}
+}
+
+func TestIntegration_GetRoutes(t *testing.T) {
+	c := integrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	routes, err := c.OrderExecution().GetRoutes(ctx)
+	if err != nil {
+		t.Fatalf("GetRoutes: %v", err)
+	}
+	for _, r := range routes {
+		t.Logf("route: %+v", r)
+	}
+	if len(routes) == 0 {
+		t.Error("no routes returned")
+	}
+}
+
+func TestIntegration_PlaceOrderConfirm(t *testing.T) {
+	c := integrationClient(t)
+	ids := fetchSandboxAccountIDs(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req := OrderRequest{
+		AccountID:   ids[0],
+		Symbol:      "AAPL",
+		Quantity:    1,
+		OrderType:   OrderTypeLimit,
+		TradeAction: TradeActionBuy,
+		LimitPrice:  1, // far-below-market; preview only
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	resp, err := c.OrderExecution().PlaceOrderConfirm(ctx, req)
+	if err != nil {
+		t.Fatalf("PlaceOrderConfirm: %v", err)
+	}
+	if len(resp.Confirmations) == 0 && len(resp.Errors) == 0 {
+		t.Error("empty confirmation response")
+	}
+	for _, c := range resp.Confirmations {
+		t.Logf("confirmation: %+v", c)
+	}
+	for _, e := range resp.Errors {
+		t.Logf("error: %+v", e)
+	}
+}

--- a/orders.go
+++ b/orders.go
@@ -144,3 +144,14 @@ func (s *OrderService) CancelOrder(ctx context.Context, orderID string) error {
 	path := "/v3/orderexecution/orders/" + url.PathEscape(orderID)
 	return s.client.doJSON(ctx, "DELETE", path, nil, nil, nil)
 }
+
+func (s *OrderService) PlaceOrder(ctx context.Context, req OrderRequest) (*PlaceOrderResponse, error) {
+	if err := validateOrderRequest(&req); err != nil {
+		return nil, err
+	}
+	var out PlaceOrderResponse
+	if err := s.client.doJSON(ctx, "POST", "/v3/orderexecution/orders", nil, &req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/orders.go
+++ b/orders.go
@@ -1,6 +1,7 @@
 package tradestation
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -113,4 +114,14 @@ func validateReplaceOrderRequest(req *ReplaceOrderRequest) error {
 		return errors.New("tradestation: Duration=GTD requires TimeInForce.ExpirationDate")
 	}
 	return nil
+}
+
+func (s *OrderService) GetActivationTriggers(ctx context.Context) ([]ActivationTrigger, error) {
+	var resp struct {
+		ActivationTriggers []ActivationTrigger `json:"ActivationTriggers"`
+	}
+	if err := s.client.doJSON(ctx, "GET", "/v3/orderexecution/activationtriggers", nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.ActivationTriggers, nil
 }

--- a/orders.go
+++ b/orders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 // OrderService bundles TradeStation Order Execution REST endpoints.
@@ -134,4 +135,12 @@ func (s *OrderService) GetRoutes(ctx context.Context) ([]OrderRoute, error) {
 		return nil, err
 	}
 	return resp.Routes, nil
+}
+
+func (s *OrderService) CancelOrder(ctx context.Context, orderID string) error {
+	if orderID == "" {
+		return errors.New("tradestation: CancelOrder requires an order ID")
+	}
+	path := "/v3/orderexecution/orders/" + url.PathEscape(orderID)
+	return s.client.doJSON(ctx, "DELETE", path, nil, nil, nil)
 }

--- a/orders.go
+++ b/orders.go
@@ -181,3 +181,14 @@ func (s *OrderService) ReplaceOrder(ctx context.Context, orderID string, req Rep
 	}
 	return &out, nil
 }
+
+func (s *OrderService) PlaceOrderGroup(ctx context.Context, req OrderGroupRequest) (*PlaceOrderResponse, error) {
+	if err := validateOrderGroupRequest(&req); err != nil {
+		return nil, err
+	}
+	var out PlaceOrderResponse
+	if err := s.client.doJSON(ctx, "POST", "/v3/orderexecution/ordergroups", nil, &req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/orders.go
+++ b/orders.go
@@ -166,3 +166,18 @@ func (s *OrderService) PlaceOrderConfirm(ctx context.Context, req OrderRequest) 
 	}
 	return &out, nil
 }
+
+func (s *OrderService) ReplaceOrder(ctx context.Context, orderID string, req ReplaceOrderRequest) (*Order, error) {
+	if orderID == "" {
+		return nil, errors.New("tradestation: ReplaceOrder requires an order ID")
+	}
+	if err := validateReplaceOrderRequest(&req); err != nil {
+		return nil, err
+	}
+	path := "/v3/orderexecution/orders/" + url.PathEscape(orderID)
+	var out Order
+	if err := s.client.doJSON(ctx, "PUT", path, nil, &req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/orders.go
+++ b/orders.go
@@ -125,3 +125,13 @@ func (s *OrderService) GetActivationTriggers(ctx context.Context) ([]ActivationT
 	}
 	return resp.ActivationTriggers, nil
 }
+
+func (s *OrderService) GetRoutes(ctx context.Context) ([]OrderRoute, error) {
+	var resp struct {
+		Routes []OrderRoute `json:"Routes"`
+	}
+	if err := s.client.doJSON(ctx, "GET", "/v3/orderexecution/routes", nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Routes, nil
+}

--- a/orders.go
+++ b/orders.go
@@ -192,3 +192,14 @@ func (s *OrderService) PlaceOrderGroup(ctx context.Context, req OrderGroupReques
 	}
 	return &out, nil
 }
+
+func (s *OrderService) PlaceOrderGroupConfirm(ctx context.Context, req OrderGroupRequest) (*ConfirmationResponse, error) {
+	if err := validateOrderGroupRequest(&req); err != nil {
+		return nil, err
+	}
+	var out ConfirmationResponse
+	if err := s.client.doJSON(ctx, "POST", "/v3/orderexecution/ordergroupsconfirm", nil, &req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/orders.go
+++ b/orders.go
@@ -1,17 +1,116 @@
 package tradestation
 
+import (
+	"errors"
+	"fmt"
+)
+
+// OrderService bundles TradeStation Order Execution REST endpoints.
 type OrderService struct {
 	client *Client
 }
 
-func (s *OrderService) PlaceOrder(req OrderRequest) (*Order, error) {
-	panic("not implemented")
+// OrderExecution returns an OrderService bound to this client.
+func (c *Client) OrderExecution() *OrderService {
+	return &OrderService{client: c}
 }
 
-func (s *OrderService) ReplaceOrder(orderID string, req OrderRequest) (*Order, error) {
-	panic("not implemented")
+func validateOrderRequest(req *OrderRequest) error {
+	if req.AccountID == "" {
+		return errors.New("tradestation: OrderRequest.AccountID is required")
+	}
+	if req.Symbol == "" {
+		return errors.New("tradestation: OrderRequest.Symbol is required")
+	}
+	if req.Quantity <= 0 {
+		return errors.New("tradestation: OrderRequest.Quantity must be positive")
+	}
+	if req.OrderType == "" {
+		return errors.New("tradestation: OrderRequest.OrderType is required")
+	}
+	if req.TradeAction == "" {
+		return errors.New("tradestation: OrderRequest.TradeAction is required")
+	}
+	if req.TimeInForce.Duration == "" {
+		return errors.New("tradestation: OrderRequest.TimeInForce.Duration is required")
+	}
+	if req.TimeInForce.Duration == DurationGTD && req.TimeInForce.ExpirationDate == "" {
+		return errors.New("tradestation: Duration=GTD requires TimeInForce.ExpirationDate")
+	}
+
+	switch req.OrderType {
+	case OrderTypeMarket:
+		if req.LimitPrice != 0 || req.StopPrice != 0 {
+			return errors.New("tradestation: Market orders must not set LimitPrice or StopPrice")
+		}
+	case OrderTypeLimit:
+		if req.LimitPrice <= 0 {
+			return errors.New("tradestation: Limit orders require positive LimitPrice")
+		}
+		if req.StopPrice != 0 {
+			return errors.New("tradestation: Limit orders must not set StopPrice")
+		}
+	case OrderTypeStopMarket:
+		if req.StopPrice <= 0 {
+			return errors.New("tradestation: StopMarket orders require positive StopPrice")
+		}
+		if req.LimitPrice != 0 {
+			return errors.New("tradestation: StopMarket orders must not set LimitPrice")
+		}
+	case OrderTypeStopLimit:
+		if req.LimitPrice <= 0 || req.StopPrice <= 0 {
+			return errors.New("tradestation: StopLimit orders require positive LimitPrice and StopPrice")
+		}
+	}
+
+	if len(req.Legs) > 0 {
+		if err := validateOrderLegs(req.Legs); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (s *OrderService) CancelOrder(orderID string) error {
-	panic("not implemented")
+func validateOrderLegs(legs []OrderLegRequest) error {
+	for i, leg := range legs {
+		if leg.Symbol == "" {
+			return fmt.Errorf("tradestation: Legs[%d].Symbol is required", i)
+		}
+		if leg.Quantity <= 0 {
+			return fmt.Errorf("tradestation: Legs[%d].Quantity must be positive", i)
+		}
+		if leg.TradeAction == "" {
+			return fmt.Errorf("tradestation: Legs[%d].TradeAction is required", i)
+		}
+	}
+	return nil
+}
+
+func validateOrderGroupRequest(req *OrderGroupRequest) error {
+	if req.Type == "" {
+		return errors.New("tradestation: OrderGroupRequest.Type is required")
+	}
+	if len(req.Orders) < 2 {
+		return errors.New("tradestation: OrderGroupRequest.Orders must contain at least 2 orders")
+	}
+	for i := range req.Orders {
+		if err := validateOrderRequest(&req.Orders[i]); err != nil {
+			return fmt.Errorf("tradestation: OrderGroupRequest.Orders[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateReplaceOrderRequest(req *ReplaceOrderRequest) error {
+	if req.Quantity == 0 && req.LimitPrice == 0 && req.StopPrice == 0 &&
+		req.TimeInForce == nil && req.AdvancedOptions == "" {
+		return errors.New("tradestation: ReplaceOrderRequest has no modifications")
+	}
+	if req.Quantity < 0 || req.LimitPrice < 0 || req.StopPrice < 0 {
+		return errors.New("tradestation: ReplaceOrderRequest values must be non-negative")
+	}
+	if req.TimeInForce != nil && req.TimeInForce.Duration == DurationGTD && req.TimeInForce.ExpirationDate == "" {
+		return errors.New("tradestation: Duration=GTD requires TimeInForce.ExpirationDate")
+	}
+	return nil
 }

--- a/orders.go
+++ b/orders.go
@@ -155,3 +155,14 @@ func (s *OrderService) PlaceOrder(ctx context.Context, req OrderRequest) (*Place
 	}
 	return &out, nil
 }
+
+func (s *OrderService) PlaceOrderConfirm(ctx context.Context, req OrderRequest) (*ConfirmationResponse, error) {
+	if err := validateOrderRequest(&req); err != nil {
+		return nil, err
+	}
+	var out ConfirmationResponse
+	if err := s.client.doJSON(ctx, "POST", "/v3/orderexecution/orderconfirm", nil, &req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -466,3 +466,43 @@ func TestReplaceOrder_ValidationBeforeHTTP(t *testing.T) {
 		t.Error("want validation error for empty mods")
 	}
 }
+
+func TestPlaceOrderGroup_RequestShape(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"Orders":[{"OrderID":"A","Message":"ok"},{"OrderID":"B","Message":"ok"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	group := OrderGroupRequest{
+		Type:   OrderGroupTypeOCO,
+		Orders: []OrderRequest{validOrder(), validOrder()},
+	}
+	resp, err := c.OrderExecution().PlaceOrderGroup(context.Background(), group)
+	if err != nil {
+		t.Fatalf("PlaceOrderGroup: %v", err)
+	}
+	if gotPath != "/v3/orderexecution/ordergroups" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(string(gotBody), `"Type":"OCO"`) {
+		t.Errorf("body missing Type: %s", string(gotBody))
+	}
+	if len(resp.Orders) != 2 {
+		t.Errorf("orders = %d, want 2", len(resp.Orders))
+	}
+}
+
+func TestPlaceOrderGroup_ValidationBeforeHTTP(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	bad := OrderGroupRequest{Type: OrderGroupTypeOCO, Orders: []OrderRequest{validOrder()}}
+	if _, err := c.OrderExecution().PlaceOrderGroup(context.Background(), bad); err == nil {
+		t.Error("want validation error")
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -410,5 +411,58 @@ func TestPlaceOrderConfirm_RequestShape(t *testing.T) {
 	}
 	if len(resp.Confirmations) != 1 || resp.Confirmations[0].OrderConfirmID != "abc" {
 		t.Errorf("decoded wrong: %+v", resp)
+	}
+}
+
+func TestReplaceOrder_RequestShape(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"OrderID":"1184080","AccountID":"123","Status":"Open"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	o, err := c.OrderExecution().ReplaceOrder(context.Background(), "1184080", ReplaceOrderRequest{Quantity: 20})
+	if err != nil {
+		t.Fatalf("ReplaceOrder: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotPath != "/v3/orderexecution/orders/1184080" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(string(gotBody), `"Quantity":"20"`) {
+		t.Errorf("body did not encode Quantity as string: %s", string(gotBody))
+	}
+	if o.OrderID != "1184080" {
+		t.Errorf("response decoded wrong: %+v", o)
+	}
+}
+
+func TestReplaceOrder_RejectsEmptyID(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	if _, err := c.OrderExecution().ReplaceOrder(context.Background(), "", ReplaceOrderRequest{Quantity: 1}); err == nil {
+		t.Error("want error for empty orderID")
+	}
+}
+
+func TestReplaceOrder_ValidationBeforeHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called")
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	if _, err := c.OrderExecution().ReplaceOrder(context.Background(), "1", ReplaceOrderRequest{}); err == nil {
+		t.Error("want validation error for empty mods")
 	}
 }

--- a/orders_test.go
+++ b/orders_test.go
@@ -278,3 +278,33 @@ func TestGetRoutes(t *testing.T) {
 		t.Errorf("decoded wrong: %+v", routes)
 	}
 }
+
+func TestCancelOrder_RequestShape(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"OrderID":"1184080","Message":"Cancel submitted"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	if err := c.OrderExecution().CancelOrder(context.Background(), "1184080"); err != nil {
+		t.Fatalf("CancelOrder: %v", err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotPath != "/v3/orderexecution/orders/1184080" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestCancelOrder_RejectsEmptyID(t *testing.T) {
+	c := NewClient(Test, "id", "secret", "refresh")
+	if err := c.OrderExecution().CancelOrder(context.Background(), ""); err == nil {
+		t.Error("want error for empty orderID")
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -252,3 +252,29 @@ func TestGetActivationTriggers(t *testing.T) {
 		t.Errorf("decoded wrong: %+v", triggers)
 	}
 }
+
+func TestGetRoutes(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"Routes":[
+            {"Id":"Intelligent","Name":"Intelligent","AssetTypes":["STOCK","STOCKOPTION"]},
+            {"Id":"NYSE","Name":"NYSE","AssetTypes":["STOCK"]}
+        ]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	routes, err := c.OrderExecution().GetRoutes(context.Background())
+	if err != nil {
+		t.Fatalf("GetRoutes: %v", err)
+	}
+	if gotPath != "/v3/orderexecution/routes" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if len(routes) != 2 || routes[0].ID != "Intelligent" {
+		t.Errorf("decoded wrong: %+v", routes)
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -506,3 +506,30 @@ func TestPlaceOrderGroup_ValidationBeforeHTTP(t *testing.T) {
 		t.Error("want validation error")
 	}
 }
+
+func TestPlaceOrderGroupConfirm_RequestShape(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"Confirmations":[{"OrderConfirmID":"abc","Route":"R","Duration":"DAY","Account":"123","SummaryMessage":"ok","EstimatedCommission":"0","EstimatedPrice":"1","EstimatedCost":"1","DebitCreditEstimatedCost":"1"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	group := OrderGroupRequest{
+		Type:   OrderGroupTypeBracket,
+		Orders: []OrderRequest{validOrder(), validOrder()},
+	}
+	resp, err := c.OrderExecution().PlaceOrderGroupConfirm(context.Background(), group)
+	if err != nil {
+		t.Fatalf("PlaceOrderGroupConfirm: %v", err)
+	}
+	if gotPath != "/v3/orderexecution/ordergroupsconfirm" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if len(resp.Confirmations) != 1 {
+		t.Errorf("confirmations = %d, want 1", len(resp.Confirmations))
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -389,3 +389,26 @@ func TestPlaceOrder_ValidationBeforeHTTP(t *testing.T) {
 		t.Error("want validation error")
 	}
 }
+
+func TestPlaceOrderConfirm_RequestShape(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"Confirmations":[{"OrderConfirmID":"abc","Route":"Intelligent","Duration":"DAY","Account":"123","SummaryMessage":"ok","EstimatedCommission":"0","EstimatedPrice":"150","EstimatedCost":"1500","DebitCreditEstimatedCost":"-1500"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	resp, err := c.OrderExecution().PlaceOrderConfirm(context.Background(), validOrder())
+	if err != nil {
+		t.Fatalf("PlaceOrderConfirm: %v", err)
+	}
+	if gotPath != "/v3/orderexecution/orderconfirm" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if len(resp.Confirmations) != 1 || resp.Confirmations[0].OrderConfirmID != "abc" {
+		t.Errorf("decoded wrong: %+v", resp)
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -1,6 +1,9 @@
 package tradestation
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -217,5 +220,35 @@ func TestValidateReplaceOrderRequest_AcceptsValidModification(t *testing.T) {
 	req := ReplaceOrderRequest{Quantity: 10}
 	if err := validateReplaceOrderRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetActivationTriggers(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"ActivationTriggers":[
+            {"Key":"STT","Name":"Single Trade Tick","Description":"..."},
+            {"Key":"DTT","Name":"Double Trade Tick","Description":"..."}
+        ]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	triggers, err := c.OrderExecution().GetActivationTriggers(context.Background())
+	if err != nil {
+		t.Fatalf("GetActivationTriggers: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotPath != "/v3/orderexecution/activationtriggers" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if len(triggers) != 2 || triggers[0].Key != "STT" {
+		t.Errorf("decoded wrong: %+v", triggers)
 	}
 }

--- a/orders_test.go
+++ b/orders_test.go
@@ -1,0 +1,221 @@
+package tradestation
+
+import (
+	"testing"
+)
+
+func validOrder() OrderRequest {
+	return OrderRequest{
+		AccountID:   "123",
+		Symbol:      "AAPL",
+		Quantity:    10,
+		OrderType:   OrderTypeLimit,
+		TradeAction: TradeActionBuy,
+		LimitPrice:  150,
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+}
+
+func TestValidateOrderRequest_HappyPath(t *testing.T) {
+	req := validOrder()
+	if err := validateOrderRequest(&req); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateOrderRequest_RequiresAccountID(t *testing.T) {
+	req := validOrder()
+	req.AccountID = ""
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for empty AccountID")
+	}
+}
+
+func TestValidateOrderRequest_RequiresSymbol(t *testing.T) {
+	req := validOrder()
+	req.Symbol = ""
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for empty Symbol")
+	}
+}
+
+func TestValidateOrderRequest_RequiresPositiveQuantity(t *testing.T) {
+	req := validOrder()
+	req.Quantity = 0
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for zero Quantity")
+	}
+	req.Quantity = -1
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for negative Quantity")
+	}
+}
+
+func TestValidateOrderRequest_RequiresOrderType(t *testing.T) {
+	req := validOrder()
+	req.OrderType = ""
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for empty OrderType")
+	}
+}
+
+func TestValidateOrderRequest_RequiresTradeAction(t *testing.T) {
+	req := validOrder()
+	req.TradeAction = ""
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for empty TradeAction")
+	}
+}
+
+func TestValidateOrderRequest_RequiresDuration(t *testing.T) {
+	req := validOrder()
+	req.TimeInForce.Duration = ""
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for empty Duration")
+	}
+}
+
+func TestValidateOrderRequest_GTDRequiresExpirationDate(t *testing.T) {
+	req := validOrder()
+	req.TimeInForce = TimeInForce{Duration: DurationGTD}
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for GTD without ExpirationDate")
+	}
+}
+
+func TestValidateOrderRequest_MarketRejectsPrices(t *testing.T) {
+	req := validOrder()
+	req.OrderType = OrderTypeMarket
+	req.LimitPrice = 150
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for Market with LimitPrice")
+	}
+
+	req = validOrder()
+	req.OrderType = OrderTypeMarket
+	req.LimitPrice = 0
+	req.StopPrice = 150
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for Market with StopPrice")
+	}
+}
+
+func TestValidateOrderRequest_LimitRequiresLimitPrice(t *testing.T) {
+	req := validOrder()
+	req.OrderType = OrderTypeLimit
+	req.LimitPrice = 0
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for Limit without LimitPrice")
+	}
+}
+
+func TestValidateOrderRequest_LimitRejectsStopPrice(t *testing.T) {
+	req := validOrder()
+	req.OrderType = OrderTypeLimit
+	req.LimitPrice = 150
+	req.StopPrice = 140
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for Limit with StopPrice")
+	}
+}
+
+func TestValidateOrderRequest_StopMarketRequiresStopPrice(t *testing.T) {
+	req := validOrder()
+	req.OrderType = OrderTypeStopMarket
+	req.LimitPrice = 0
+	req.StopPrice = 0
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for StopMarket without StopPrice")
+	}
+}
+
+func TestValidateOrderRequest_StopLimitRequiresBoth(t *testing.T) {
+	req := validOrder()
+	req.OrderType = OrderTypeStopLimit
+	req.LimitPrice = 150
+	req.StopPrice = 0
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for StopLimit without StopPrice")
+	}
+	req.LimitPrice = 0
+	req.StopPrice = 140
+	if err := validateOrderRequest(&req); err == nil {
+		t.Error("want error for StopLimit without LimitPrice")
+	}
+}
+
+func TestValidateOrderLegs_EmptySymbol(t *testing.T) {
+	legs := []OrderLegRequest{{Quantity: 1, TradeAction: TradeActionBuyToOpen}}
+	if err := validateOrderLegs(legs); err == nil {
+		t.Error("want error for missing Symbol")
+	}
+}
+
+func TestValidateOrderLegs_NonPositiveQuantity(t *testing.T) {
+	legs := []OrderLegRequest{{Symbol: "X", Quantity: 0, TradeAction: TradeActionBuyToOpen}}
+	if err := validateOrderLegs(legs); err == nil {
+		t.Error("want error for zero Quantity")
+	}
+}
+
+func TestValidateOrderLegs_MissingTradeAction(t *testing.T) {
+	legs := []OrderLegRequest{{Symbol: "X", Quantity: 1}}
+	if err := validateOrderLegs(legs); err == nil {
+		t.Error("want error for missing TradeAction")
+	}
+}
+
+func TestValidateOrderGroupRequest_RequiresType(t *testing.T) {
+	g := OrderGroupRequest{Orders: []OrderRequest{validOrder(), validOrder()}}
+	if err := validateOrderGroupRequest(&g); err == nil {
+		t.Error("want error for empty Type")
+	}
+}
+
+func TestValidateOrderGroupRequest_RequiresTwoOrders(t *testing.T) {
+	g := OrderGroupRequest{Type: OrderGroupTypeOCO, Orders: []OrderRequest{validOrder()}}
+	if err := validateOrderGroupRequest(&g); err == nil {
+		t.Error("want error for single-order group")
+	}
+}
+
+func TestValidateOrderGroupRequest_PropagatesPerOrderErrors(t *testing.T) {
+	bad := validOrder()
+	bad.Symbol = ""
+	g := OrderGroupRequest{Type: OrderGroupTypeOCO, Orders: []OrderRequest{validOrder(), bad}}
+	if err := validateOrderGroupRequest(&g); err == nil {
+		t.Error("want error from per-order validation")
+	}
+}
+
+func TestValidateReplaceOrderRequest_RequiresModification(t *testing.T) {
+	if err := validateReplaceOrderRequest(&ReplaceOrderRequest{}); err == nil {
+		t.Error("want error for empty modifications")
+	}
+}
+
+func TestValidateReplaceOrderRequest_RejectsNegatives(t *testing.T) {
+	if err := validateReplaceOrderRequest(&ReplaceOrderRequest{Quantity: -1}); err == nil {
+		t.Error("want error for negative Quantity")
+	}
+	if err := validateReplaceOrderRequest(&ReplaceOrderRequest{LimitPrice: -1}); err == nil {
+		t.Error("want error for negative LimitPrice")
+	}
+	if err := validateReplaceOrderRequest(&ReplaceOrderRequest{StopPrice: -1}); err == nil {
+		t.Error("want error for negative StopPrice")
+	}
+}
+
+func TestValidateReplaceOrderRequest_GTDRequiresExpirationDate(t *testing.T) {
+	req := ReplaceOrderRequest{TimeInForce: &TimeInForce{Duration: DurationGTD}}
+	if err := validateReplaceOrderRequest(&req); err == nil {
+		t.Error("want error for GTD without ExpirationDate")
+	}
+}
+
+func TestValidateReplaceOrderRequest_AcceptsValidModification(t *testing.T) {
+	req := ReplaceOrderRequest{Quantity: 10}
+	if err := validateReplaceOrderRequest(&req); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -2,6 +2,8 @@ package tradestation
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -306,5 +308,84 @@ func TestCancelOrder_RejectsEmptyID(t *testing.T) {
 	c := NewClient(Test, "id", "secret", "refresh")
 	if err := c.OrderExecution().CancelOrder(context.Background(), ""); err == nil {
 		t.Error("want error for empty orderID")
+	}
+}
+
+func TestPlaceOrder_RequestShape(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"Orders":[{"OrderID":"1184080","Message":"Order placed"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	resp, err := c.OrderExecution().PlaceOrder(context.Background(), validOrder())
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v3/orderexecution/orders" {
+		t.Errorf("method=%q path=%q", gotMethod, gotPath)
+	}
+
+	// Verify body encoded Quantity and LimitPrice as JSON strings.
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if decoded["Quantity"] != "10" {
+		t.Errorf("Quantity = %v, want \"10\"", decoded["Quantity"])
+	}
+	if decoded["LimitPrice"] != "150" {
+		t.Errorf("LimitPrice = %v, want \"150\"", decoded["LimitPrice"])
+	}
+
+	if len(resp.Orders) != 1 || resp.Orders[0].OrderID != "1184080" {
+		t.Errorf("response wrong: %+v", resp)
+	}
+}
+
+func TestPlaceOrder_PartialError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+            "Orders":[{"OrderID":"1","Message":"ok"}],
+            "Errors":[{"OrderNumber":"0","Error":"InsufficientBuyingPower","Message":"denied"}]
+        }`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	resp, err := c.OrderExecution().PlaceOrder(context.Background(), validOrder())
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	if len(resp.Orders) != 1 || len(resp.Errors) != 1 {
+		t.Fatalf("want 1 order + 1 error: %+v", resp)
+	}
+	if resp.Errors[0].ErrorCode != "InsufficientBuyingPower" {
+		t.Errorf("ErrorCode = %q", resp.Errors[0].ErrorCode)
+	}
+}
+
+func TestPlaceOrder_ValidationBeforeHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called")
+	}))
+	defer srv.Close()
+
+	c := NewClient(Test, "id", "secret", "refresh")
+	c.apiBase = srv.URL
+
+	req := validOrder()
+	req.AccountID = ""
+	if _, err := c.OrderExecution().PlaceOrder(context.Background(), req); err == nil {
+		t.Error("want validation error")
 	}
 }

--- a/types.go
+++ b/types.go
@@ -555,3 +555,66 @@ type OrdersResponse struct {
 	Orders []Order        `json:"Orders"`
 	Errors []AccountError `json:"Errors,omitempty"`
 }
+
+// PlaceOrderResponse is the response body of PlaceOrder / PlaceOrderGroup.
+// Orders contains successfully placed orders; Errors contains per-order
+// rejections. A 200 response may carry both.
+type PlaceOrderResponse struct {
+	Orders []PlacedOrder `json:"Orders"`
+	Errors []OrderError  `json:"Errors,omitempty"`
+}
+
+// PlacedOrder is the thin confirmation returned by the server for each
+// successfully placed order. Use Brokerage.GetOrdersByID to fetch the full
+// Order payload.
+type PlacedOrder struct {
+	OrderID string `json:"OrderID"`
+	Message string `json:"Message"`
+}
+
+// OrderError is a per-order rejection inside a placement response.
+type OrderError struct {
+	// OrderNumber is the index into the request's Orders array (or "0" for
+	// single-order placements).
+	OrderNumber string `json:"OrderNumber"`
+	// ErrorCode is the machine-readable error category (e.g.
+	// "InsufficientBuyingPower"). Named ErrorCode in Go to avoid collision
+	// with the error interface method.
+	ErrorCode string `json:"Error"`
+	Message   string `json:"Message"`
+}
+
+// ConfirmationResponse is the response body of PlaceOrderConfirm /
+// PlaceOrderGroupConfirm — previews without execution.
+type ConfirmationResponse struct {
+	Confirmations []OrderConfirmation `json:"Confirmations"`
+	Errors        []OrderError        `json:"Errors,omitempty"`
+}
+
+// OrderConfirmation previews an order. Pass OrderConfirmID on a subsequent
+// PlaceOrder to submit the previewed order for execution.
+type OrderConfirmation struct {
+	OrderConfirmID           string        `json:"OrderConfirmID"`
+	Route                    string        `json:"Route"`
+	Duration                 string        `json:"Duration"`
+	Account                  string        `json:"Account"`
+	SummaryMessage           string        `json:"SummaryMessage"`
+	EstimatedCommission      StringFloat64 `json:"EstimatedCommission"`
+	EstimatedPrice           StringFloat64 `json:"EstimatedPrice"`
+	EstimatedPriceDisplay    string        `json:"EstimatedPriceDisplay"`
+	EstimatedCost            StringFloat64 `json:"EstimatedCost"`
+	EstimatedCostDisplay     string        `json:"EstimatedCostDisplay"`
+	DebitCreditEstimatedCost StringFloat64 `json:"DebitCreditEstimatedCost"`
+	InitialMarginDisplay     string        `json:"InitialMarginDisplay"`
+	ProductCurrency          string        `json:"ProductCurrency"`
+	AccountCurrency          string        `json:"AccountCurrency"`
+}
+
+// ActivationTrigger describes a valid activation-trigger identifier for
+// stop / trigger orders. Retrieved via GetActivationTriggers. Use the Key
+// in OrderRequest.AdvancedOptions.
+type ActivationTrigger struct {
+	Key         string `json:"Key"` // e.g. "STT", "DTT", "SBA"
+	Name        string `json:"Name"`
+	Description string `json:"Description"`
+}

--- a/types.go
+++ b/types.go
@@ -27,6 +27,12 @@ func (f *StringFloat64) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON emits a JSON-encoded string ("10.5"), matching TradeStation's
+// wire format for numeric fields in request bodies.
+func (f StringFloat64) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.AppendQuote(nil, strconv.FormatFloat(float64(f), 'f', -1, 64))), nil
+}
+
 // StringInt64 unmarshals from both JSON strings ("100") and numbers (100).
 type StringInt64 int64
 
@@ -46,6 +52,12 @@ func (i *StringInt64) UnmarshalJSON(data []byte) error {
 	}
 	*i = StringInt64(n)
 	return nil
+}
+
+// MarshalJSON emits a JSON-encoded string ("100"), matching TradeStation's
+// wire format for numeric fields in request bodies.
+func (i StringInt64) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.AppendQuote(nil, strconv.FormatInt(int64(i), 10))), nil
 }
 
 // MarketData types
@@ -316,6 +328,107 @@ type OrderRequest struct {
 	Duration    string  `json:"Duration"`
 	Route       string  `json:"Route,omitempty"`
 }
+
+// OrderType is the execution style for an order. Different OrderTypes require
+// different price fields on OrderRequest:
+//
+//   - OrderTypeMarket:     no price fields
+//   - OrderTypeLimit:      LimitPrice required
+//   - OrderTypeStopMarket: StopPrice required
+//   - OrderTypeStopLimit:  both LimitPrice and StopPrice required
+type OrderType string
+
+const (
+	// OrderTypeMarket executes immediately at the best available price.
+	// Must not set LimitPrice or StopPrice.
+	OrderTypeMarket OrderType = "Market"
+
+	// OrderTypeLimit executes only at LimitPrice or better.
+	// Requires OrderRequest.LimitPrice > 0.
+	OrderTypeLimit OrderType = "Limit"
+
+	// OrderTypeStopMarket becomes a market order once the last trade reaches
+	// StopPrice. Requires OrderRequest.StopPrice > 0.
+	OrderTypeStopMarket OrderType = "StopMarket"
+
+	// OrderTypeStopLimit becomes a limit order once StopPrice is reached,
+	// then executes only at LimitPrice or better. Requires both
+	// OrderRequest.StopPrice > 0 and OrderRequest.LimitPrice > 0.
+	OrderTypeStopLimit OrderType = "StopLimit"
+)
+
+// TradeAction names the buy/sell side of an order. Equity and option trades
+// use different action sets:
+//
+//   - Equities: BUY, SELL, BUYTOCOVER, SELLSHORT
+//   - Options:  BUYTOOPEN, BUYTOCLOSE, SELLTOOPEN, SELLTOCLOSE
+//
+// Using an option action on an equity order (or vice versa) will be rejected
+// by the server.
+type TradeAction string
+
+const (
+	// TradeActionBuy opens or increases a long equity position.
+	TradeActionBuy TradeAction = "BUY"
+	// TradeActionSell closes or reduces a long equity position.
+	TradeActionSell TradeAction = "SELL"
+	// TradeActionBuyToCover closes a short equity position by buying back
+	// the borrowed shares.
+	TradeActionBuyToCover TradeAction = "BUYTOCOVER"
+	// TradeActionSellShort opens or increases a short equity position.
+	// Requires a margin account and locatable borrow.
+	TradeActionSellShort TradeAction = "SELLSHORT"
+	// TradeActionBuyToOpen opens a new long option position. Options only.
+	TradeActionBuyToOpen TradeAction = "BUYTOOPEN"
+	// TradeActionBuyToClose closes an existing short option position. Options only.
+	TradeActionBuyToClose TradeAction = "BUYTOCLOSE"
+	// TradeActionSellToOpen opens a new short option position (write). Options only.
+	TradeActionSellToOpen TradeAction = "SELLTOOPEN"
+	// TradeActionSellToClose closes an existing long option position. Options only.
+	TradeActionSellToClose TradeAction = "SELLTOCLOSE"
+)
+
+// Duration is the time-in-force policy — how long an order remains active
+// before automatic cancellation.
+type Duration string
+
+const (
+	// DurationDay: active only during the current trading session.
+	DurationDay Duration = "DAY"
+	// DurationGTC (good-til-canceled): active across sessions until filled or
+	// explicitly canceled, subject to broker maximum GTC age.
+	DurationGTC Duration = "GTC"
+	// DurationGTD (good-til-date): active until TimeInForce.ExpirationDate.
+	// Requires TimeInForce.ExpirationDate to be a future ISO8601 date.
+	DurationGTD Duration = "GTD"
+	// DurationIOC (immediate-or-cancel): any portion that can't fill immediately
+	// is canceled. Partial fills allowed.
+	DurationIOC Duration = "IOC"
+	// DurationFOK (fill-or-kill): the entire quantity must fill immediately or
+	// the order is canceled. No partial fills.
+	DurationFOK Duration = "FOK"
+	// DurationOPG: participates in the opening auction only.
+	DurationOPG Duration = "OPG"
+	// DurationCLO: participates in the closing auction only.
+	DurationCLO Duration = "CLO"
+)
+
+// OrderGroupType determines how orders in a PlaceOrderGroup relate to each
+// other after placement.
+type OrderGroupType string
+
+const (
+	// OrderGroupTypeBracket (BRK): a parent order with one or more child
+	// exits (typically a profit-target limit plus a stop-loss). When one
+	// child fills or cancels, the others are automatically canceled.
+	OrderGroupTypeBracket OrderGroupType = "BRK"
+	// OrderGroupTypeOCO (one-cancels-other): peer orders where any fill
+	// cancels the remaining orders in the group. No parent.
+	OrderGroupTypeOCO OrderGroupType = "OCO"
+	// OrderGroupTypeNormal: orders are submitted together but operate
+	// independently (not linked).
+	OrderGroupTypeNormal OrderGroupType = "NORMAL"
+)
 
 // Brokerage response wrappers — carry both data and partial per-account errors.
 

--- a/types.go
+++ b/types.go
@@ -316,17 +316,115 @@ type ConditionalOrder struct {
 	Relationship string `json:"Relationship"`
 }
 
-// OrderRequest stays as-is (used by OrderService stubs, out of scope for this branch).
+// OrderRequest is the body of POST /orderexecution/orders and POST /orderconfirm.
+// Required fields: AccountID, Symbol, Quantity, OrderType, TradeAction,
+// TimeInForce.Duration. OrderType determines which price fields must be set.
 type OrderRequest struct {
-	AccountID   string  `json:"AccountID"`
-	Symbol      string  `json:"Symbol"`
-	Quantity    int64   `json:"Quantity"`
-	OrderType   string  `json:"OrderType"`
-	LimitPrice  float64 `json:"LimitPrice,omitempty"`
-	StopPrice   float64 `json:"StopPrice,omitempty"`
-	TradeAction string  `json:"TradeAction"`
-	Duration    string  `json:"Duration"`
-	Route       string  `json:"Route,omitempty"`
+	// AccountID is the TradeStation account ID the order is placed against.
+	AccountID string `json:"AccountID"`
+
+	// Symbol is the security identifier (e.g. "AAPL" for stock, option
+	// symbols follow TradeStation's symbology format).
+	Symbol string `json:"Symbol"`
+
+	// Quantity is the number of shares or contracts. Must be positive.
+	// Supports fractional values for assets that permit them.
+	Quantity StringFloat64 `json:"Quantity"`
+
+	// OrderType — see OrderType constants for price-field requirements.
+	OrderType OrderType `json:"OrderType"`
+
+	// TradeAction — see TradeAction constants for equity vs option semantics.
+	TradeAction TradeAction `json:"TradeAction"`
+
+	// LimitPrice is required for OrderTypeLimit and OrderTypeStopLimit;
+	// must not be set for Market or StopMarket.
+	LimitPrice StringFloat64 `json:"LimitPrice,omitempty"`
+
+	// StopPrice is required for OrderTypeStopMarket and OrderTypeStopLimit;
+	// must not be set for Market or Limit.
+	StopPrice StringFloat64 `json:"StopPrice,omitempty"`
+
+	// TimeInForce controls how long the order remains active. Duration is
+	// required; ExpirationDate is required when Duration=DurationGTD.
+	TimeInForce TimeInForce `json:"TimeInForce"`
+
+	// Route is the execution venue ID. Use OrderService.GetRoutes to list
+	// valid routes. Optional — server picks a default when unset.
+	Route string `json:"Route,omitempty"`
+
+	// BuyingPowerWarning controls buying-power-exceeded handling, typically
+	// "Enforce" (default) or "Preconfirmed".
+	BuyingPowerWarning string `json:"BuyingPowerWarning,omitempty"`
+
+	// AdvancedOptions is an opaque string for advanced order features
+	// (trailing stops, activation triggers, all-or-none, etc.). See spec.
+	AdvancedOptions string `json:"AdvancedOptions,omitempty"`
+
+	// OrderConfirmID references a prior PlaceOrderConfirm response,
+	// binding placement to a previewed order for safety.
+	OrderConfirmID string `json:"OrderConfirmID,omitempty"`
+
+	// Legs populates multi-leg (option spread) orders. Must use option
+	// TradeActions (BUYTOOPEN / SELLTOOPEN / BUYTOCLOSE / SELLTOCLOSE).
+	Legs []OrderLegRequest `json:"Legs,omitempty"`
+
+	// OSOs (order-sends-order) fire child order groups only if this parent
+	// order fills. Nested OSOs are allowed.
+	OSOs []OSOOrderRequest `json:"OSOs,omitempty"`
+}
+
+// TimeInForce controls how long an order remains active before
+// automatic cancellation.
+type TimeInForce struct {
+	// Duration is required; see Duration constants for semantics.
+	Duration Duration `json:"Duration"`
+	// ExpirationDate is an ISO8601 date (e.g. "2026-12-31"). Required when
+	// Duration is DurationGTD; ignored for other durations.
+	ExpirationDate string `json:"ExpirationDate,omitempty"`
+}
+
+// OrderLegRequest describes one leg of a multi-leg option order.
+// TradeAction must be an option-variant action.
+type OrderLegRequest struct {
+	Symbol         string        `json:"Symbol"`
+	Quantity       StringFloat64 `json:"Quantity"`
+	TradeAction    TradeAction   `json:"TradeAction"`
+	AssetType      string        `json:"AssetType,omitempty"`
+	ExpirationDate string        `json:"ExpirationDate,omitempty"` // option expiration
+	StrikePrice    StringFloat64 `json:"StrikePrice,omitempty"`
+	OptionType     string        `json:"OptionType,omitempty"` // CALL | PUT
+}
+
+// OSOOrderRequest (order-sends-order) describes a child order group that
+// activates only when the parent order fills. The child group itself has a
+// Type (bracket, OCO, or normal) and contains 1+ orders. Chaining is allowed
+// via OrderRequest.OSOs on the child orders.
+type OSOOrderRequest struct {
+	Type   OrderGroupType `json:"Type"`
+	Orders []OrderRequest `json:"Orders"`
+}
+
+// ReplaceOrderRequest is the body of PUT /orders/{orderID}. Contains only
+// fields the spec allows to modify on an open order. All fields are optional;
+// at least one must be set or the request is rejected at the validation
+// boundary.
+type ReplaceOrderRequest struct {
+	Quantity        StringFloat64 `json:"Quantity,omitempty"`
+	LimitPrice      StringFloat64 `json:"LimitPrice,omitempty"`
+	StopPrice       StringFloat64 `json:"StopPrice,omitempty"`
+	TimeInForce     *TimeInForce  `json:"TimeInForce,omitempty"`
+	AdvancedOptions string        `json:"AdvancedOptions,omitempty"`
+}
+
+// OrderGroupRequest is the body of POST /ordergroups and POST /ordergroupsconfirm.
+// Must contain at least 2 orders.
+type OrderGroupRequest struct {
+	// Type determines how the Orders relate after placement.
+	// See OrderGroupType constants.
+	Type OrderGroupType `json:"Type"`
+	// Orders is the list of orders in the group (2+ required).
+	Orders []OrderRequest `json:"Orders"`
 }
 
 // OrderType is the execution style for an order. Different OrderTypes require

--- a/types_test.go
+++ b/types_test.go
@@ -139,3 +139,48 @@ func TestTimeInForce_GTDRoundtrip(t *testing.T) {
 		t.Errorf("roundtrip lost data: %+v", got)
 	}
 }
+
+func TestPlaceOrderResponse_JSONDecode(t *testing.T) {
+	raw := `{
+        "Orders":[{"OrderID":"1184080","Message":"Order placed"}],
+        "Errors":[{"OrderNumber":"0","Error":"InsufficientBuyingPower","Message":"not enough buying power"}]
+    }`
+	var resp PlaceOrderResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(resp.Orders) != 1 || resp.Orders[0].OrderID != "1184080" {
+		t.Errorf("orders wrong: %+v", resp.Orders)
+	}
+	if len(resp.Errors) != 1 || resp.Errors[0].ErrorCode != "InsufficientBuyingPower" {
+		t.Errorf("errors wrong: %+v", resp.Errors)
+	}
+}
+
+func TestConfirmationResponse_JSONDecode(t *testing.T) {
+	raw := `{
+        "Confirmations":[{"OrderConfirmID":"abc","Route":"Intelligent","Duration":"DAY","Account":"123","SummaryMessage":"ok","EstimatedCommission":"0","EstimatedPrice":"150","EstimatedCost":"1500","DebitCreditEstimatedCost":"-1500"}]
+    }`
+	var resp ConfirmationResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(resp.Confirmations) != 1 {
+		t.Fatalf("confirmations = %d, want 1", len(resp.Confirmations))
+	}
+	c := resp.Confirmations[0]
+	if c.OrderConfirmID != "abc" || c.EstimatedPrice != 150 {
+		t.Errorf("decoded wrong: %+v", c)
+	}
+}
+
+func TestActivationTrigger_JSONDecode(t *testing.T) {
+	raw := `{"Key":"STT","Name":"Single Trade Tick","Description":"trigger on one tick"}`
+	var at ActivationTrigger
+	if err := json.Unmarshal([]byte(raw), &at); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if at.Key != "STT" || at.Name == "" || at.Description == "" {
+		t.Errorf("decoded wrong: %+v", at)
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,88 @@
+package tradestation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStringFloat64_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   StringFloat64
+		want string
+	}{
+		{"ten and a half", 10.5, `"10.5"`},
+		{"zero", 0, `"0"`},
+		{"negative", -3.25, `"-3.25"`},
+		{"large", 1234567.89, `"1234567.89"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", string(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestStringFloat64_Roundtrip(t *testing.T) {
+	orig := StringFloat64(42.75)
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got StringFloat64
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != orig {
+		t.Errorf("got %v, want %v", got, orig)
+	}
+}
+
+func TestStringInt64_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(StringInt64(100))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(got) != `"100"` {
+		t.Errorf("got %s, want \"100\"", string(got))
+	}
+}
+
+func TestStringInt64_Roundtrip(t *testing.T) {
+	orig := StringInt64(-9999)
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got StringInt64
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != orig {
+		t.Errorf("got %v, want %v", got, orig)
+	}
+}
+
+func TestOrderType_JSONRoundtrip(t *testing.T) {
+	orig := OrderTypeLimit
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(b) != `"Limit"` {
+		t.Errorf("Marshal got %s, want \"Limit\"", string(b))
+	}
+	var got OrderType
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != orig {
+		t.Errorf("Unmarshal got %q, want %q", got, orig)
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -2,6 +2,7 @@ package tradestation
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -84,5 +85,57 @@ func TestOrderType_JSONRoundtrip(t *testing.T) {
 	}
 	if got != orig {
 		t.Errorf("Unmarshal got %q, want %q", got, orig)
+	}
+}
+
+func TestOrderRequest_MarshalEncodesNumericsAsStrings(t *testing.T) {
+	req := OrderRequest{
+		AccountID:   "123",
+		Symbol:      "AAPL",
+		Quantity:    10,
+		OrderType:   OrderTypeLimit,
+		TradeAction: TradeActionBuy,
+		LimitPrice:  150.5,
+		TimeInForce: TimeInForce{Duration: DurationDay},
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(b)
+	// Quantity and LimitPrice should both be JSON strings.
+	for _, substr := range []string{
+		`"Quantity":"10"`,
+		`"LimitPrice":"150.5"`,
+		`"OrderType":"Limit"`,
+		`"TradeAction":"BUY"`,
+		`"TimeInForce":{"Duration":"DAY"}`,
+	} {
+		if !strings.Contains(got, substr) {
+			t.Errorf("missing %q in %s", substr, got)
+		}
+	}
+	// StopPrice was zero — should be omitted.
+	if strings.Contains(got, "StopPrice") {
+		t.Errorf("StopPrice should be omitted: %s", got)
+	}
+}
+
+func TestTimeInForce_GTDRoundtrip(t *testing.T) {
+	tif := TimeInForce{Duration: DurationGTD, ExpirationDate: "2026-12-31"}
+	b, err := json.Marshal(tif)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := `{"Duration":"GTD","ExpirationDate":"2026-12-31"}`
+	if string(b) != want {
+		t.Errorf("got %s, want %s", string(b), want)
+	}
+	var got TimeInForce
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Duration != DurationGTD || got.ExpirationDate != "2026-12-31" {
+		t.Errorf("roundtrip lost data: %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Implement all 8 Order Execution REST endpoints on a new `OrderService` exposed via `Client.OrderExecution()`: `PlaceOrder`, `PlaceOrderConfirm`, `PlaceOrderGroup`, `PlaceOrderGroupConfirm`, `ReplaceOrder`, `CancelOrder`, `GetActivationTriggers`, `GetRoutes`.
- Land full spec-fidelity types (`OrderRequest`, `TimeInForce`, `OrderLegRequest`, `OSOOrderRequest`, `ReplaceOrderRequest`, `OrderGroupRequest`, `PlaceOrderResponse`, `ConfirmationResponse`, `ActivationTrigger`) plus typed enum constants (`OrderType`, `TradeAction`, `Duration`, `OrderGroupType`).
- Pre-HTTP validation helpers (`validateOrderRequest`, `validateOrderLegs`, `validateOrderGroupRequest`, `validateReplaceOrderRequest`) enforce field presence and OrderType/price-field invariants before hitting the network.

## Breaking changes
- `OrderRequest` is rewritten to the new spec shape. The previous Phase‑1 struct was only referenced by panicking stubs.
- `StringFloat64` and `StringInt64` gain `MarshalJSON` that emits JSON strings to match TradeStation's wire form. Existing `UnmarshalJSON` unchanged.

## Test plan
- [x] `go test ./...` — unit tests green (validation + httptest-backed endpoint coverage).
- [x] `go vet ./...` — clean.
- [x] Safe sandbox integration tests — `go test -tags=integration -run TestIntegration_GetActivationTriggers|TestIntegration_GetRoutes|TestIntegration_PlaceOrderConfirm` — 3/3 pass.
- [x] Destructive sandbox integration tests — `TRADESTATION_INTEGRATION_PLACE_ORDERS=1 go test -tags=integration -run TestIntegration_PlaceAnd...` — 4/4 pass (real orders placed, replaced, cancelled end‑to‑end). Gated by env var; skipped by default.

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)